### PR TITLE
Update README with windows installation step

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,17 @@ To upgrade:
 brew upgrade kubefwd
 ```
 
+## Windows Install / Update
+
+```batch
+scoop install kubefwd
+```
+
+To upgrade:
+```batch
+scoop update kubefwd
+```
+
 ## Docker
 
 Forward all services from the namespace **the-project** to a Docker container named **the-project**:


### PR DESCRIPTION
Thx to lukesampson/scoop#2972 it is possible to install `kubefwd` using [scoop](https://github.com/lukesampson/scoop) installer.