### PR TITLE
Fix typo in services.go

### DIFF
--- a/cmd/kubefwd/services/services.go
+++ b/cmd/kubefwd/services/services.go
@@ -112,7 +112,7 @@ Try:
 
 		hostFile, err := txeh.NewHostsDefault()
 		if err != nil {
-			log.Fatal("Hosfile error: %s", err.Error())
+			log.Fatal("Hostfile error: %s", err.Error())
 		}
 
 		log.Printf("Loaded hosts file %s\n", hostFile.ReadFilePath)


### PR DESCRIPTION
I was reviewing the changes made for `1.6.0` and found this small typo in an error log. Thanks for all of the work to get `1.6.0` out!