### PR TITLE
Link badge to release tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Kubernetes port forwarding for local development, Contributions welcome!
 [![GitHub license](https://img.shields.io/github/license/txn2/kubefwd.svg)](https://github.com/txn2/kubefwd/blob/master/LICENSE)
 [![Maintainability](https://api.codeclimate.com/v1/badges/bc696045260db8e0ba89/maintainability)](https://codeclimate.com/github/txn2/kubefwd/maintainability)
 [![Go Report Card](https://goreportcard.com/badge/github.com/txn2/kubefwd)](https://goreportcard.com/report/github.com/txn2/kubefwd)
-![GitHub release](https://img.shields.io/github/release/txn2/kubefwd.svg)
+[![GitHub release](https://img.shields.io/github/release/txn2/kubefwd.svg)](https://github.com/txn2/kubefwd/releases)
 
 # kubefwd (Kube Forward)
 


### PR DESCRIPTION
A simple change to make navigating around a bit quicker. (The Docker Hub page doesn't seem to provide valuable information, hence linking to the GitHub release page.)