### PR TITLE
fix: No pods should be selected if the service has no selector.

### DIFF
--- a/cmd/kubefwd/services/services.go
+++ b/cmd/kubefwd/services/services.go
@@ -255,6 +255,13 @@ func fwdServices(opts FwdServiceOpts) error {
 	// loop through the services
 	for _, svc := range services.Items {
 		selector := mapToSelectorStr(svc.Spec.Selector)
+
+		if selector == "" {
+			log.Printf("WARNING: No backing pods for service %s in %s on cluster %s.\n", svc.Name, svc.Namespace, svc.ClusterName)
+
+			continue
+		}
+
 		pods, err := opts.ClientSet.CoreV1().Pods(svc.Namespace).List(metav1.ListOptions{LabelSelector: selector})
 
 		if err != nil {


### PR DESCRIPTION
According to https://github.com/kubernetes/kubernetes/issues/25836, Looking for backing pods of a service with only an empty label selector as options will return all the pods, which kubefwd will port-forward as if they really back the service. 

with two services; `myapp-myapp` with the backing pod  `myapp-myapp-59cb4d9895-lzb2l` and `kubernetes`with no backing pod (its selector is empty), `sudo kubefwd svc -n default` returns:

```
2019/03/21 15:05:08 Forwarding: kubernetes:443 to pod myapp-myapp-59cb4d9895-lzb2l:6443
2019/03/21 15:05:08 Forwarding: myapp-myapp:80 to pod myapp-myapp-59cb4d9895-lzb2l:8080
```

To avoid that, I'm thinking about neglecting services with no selectors, given the fact that we rely on services to look for pods, we will not port-forward pods without a service.