### PR TITLE
fix port forward request path

### DIFF
--- a/pkg/fwdport/fwdport.go
+++ b/pkg/fwdport/fwdport.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 
 	"github.com/prometheus/common/log"
 
@@ -63,7 +64,7 @@ func PortForward(pfo *PortForwardOpts) error {
 	u := url.URL{
 		Scheme:   req.URL().Scheme,
 		Host:     req.URL().Host,
-		Path:     "/api/v1" + req.URL().Path,
+		Path:     buildPath(req),
 		RawQuery: "timeout=32s",
 	}
 
@@ -142,4 +143,10 @@ func PortForward(pfo *PortForwardOpts) error {
 	}
 
 	return nil
+}
+
+func buildPath(req *restclient.Request) string {
+	splitted := strings.Split(req.URL().Path, "/namespaces")
+	path := splitted[0] + "/api/v1/namespaces" + splitted[1]
+	return path
 }


### PR DESCRIPTION
This fix happened based on the following observation: 

I have a cluster in my kube config with the following server address: https://rancher.my.host/k8s/clusters/dev-cluster

When trying to use kubefwd, I received an error message _404 not found_. While debugging I discovered that the request path for the port forward would look like this: 
`/api/v1/k8s/clusters/dev-cluster/namespaces/my-namespace/pods/my-pod/portforward` 
while it should look like this: 
`/k8s/clusters/dev-cluster/api/v1/namespaces/my-namespace/pods/my-pod/portforward`

The `/k8s/clusters/dev-cluster` is set by the k8s rest client, so I did not find a way besides this workaround yet.

For comparison, I tested this with a local minikube cluster aswell, which still seems to work. So hopefully, this is useful to you :)