### PR TITLE
Add warning for namespaces that have no services

### DIFF
--- a/cmd/kubefwd/services/services.go
+++ b/cmd/kubefwd/services/services.go
@@ -244,6 +244,10 @@ func fwdServices(opts FwdServiceOpts) error {
 	if err != nil {
 		return err
 	}
+	if len(services.Items) < 1 {
+		log.Printf("WARNING: No services found for namespace %s.\n", opts.Namespace)
+		return nil
+	}
 
 	publisher := &fwdpub.Publisher{
 		PublisherName: "Services",


### PR DESCRIPTION
Checks the length of the services found for the provided namespace, logs a warning if none are found, and early exits.

Resolves #57 