### PR TITLE
MOD:ListPods isNotFound error add

### DIFF
--- a/cmd/kubefwd/services/services.go
+++ b/cmd/kubefwd/services/services.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	restclient "k8s.io/client-go/rest"
+	"k8s.io/apimachinery/pkg/api/errors"
 )
 
 var namespaces []string
@@ -281,7 +282,11 @@ func fwdServices(opts FwdServiceOpts) error {
 		pods, err := opts.ClientSet.CoreV1().Pods(svc.Namespace).List(listOpts)
 
 		if err != nil {
-			log.Warnf("WARNING: No Running Pods found for %s: %s\n", selector, err.Error())
+			if errors.IsNotFound(err) {
+				log.Warnf("WARNING: No Running Pods found for %s: %s\n", selector, err.Error())
+			} else {
+				log.Warnf("WARNING: Error in List pods for %s: %s\n", selector, err.Error())
+			}
 
 			// TODO: try again after a time
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5
 	github.com/txn2/txeh v1.2.1
-	gopkg.in/yaml.v2 v2.2.4
 	k8s.io/api v0.0.0-20191031065753-b19d8caf39be
 	k8s.io/apimachinery v0.0.0-20191102025618-50aa20a7b23f
 	k8s.io/cli-runtime v0.0.0-20191102031428-d1199d98239f

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,7 @@ github.com/Azure/go-autorest/autorest/adal v0.5.0/go.mod h1:8Z9fGy2MpX0PvDjB1pEg
 github.com/Azure/go-autorest/autorest/date v0.1.0 h1:YGrhWfrgtFs84+h0o46rJrlmsZtyZRg470CqAXTZaGM=
 github.com/Azure/go-autorest/autorest/date v0.1.0/go.mod h1:plvfp3oPSKwf2DNjlBjWF/7vwR+cUD/ELuzDCXwHUVA=
 github.com/Azure/go-autorest/autorest/mocks v0.1.0/go.mod h1:OTyCOPRA2IgIlWxVYxBee2F5Gr4kF2zd2J5cFRaIDN0=
+github.com/Azure/go-autorest/autorest/mocks v0.2.0 h1:Ww5g4zThfD/6cLb4z6xxgeyDa7QDkizMkJKe0ysZXp0=
 github.com/Azure/go-autorest/autorest/mocks v0.2.0/go.mod h1:OTyCOPRA2IgIlWxVYxBee2F5Gr4kF2zd2J5cFRaIDN0=
 github.com/Azure/go-autorest/logger v0.1.0 h1:ruG4BSDXONFRrZZJ2GUXDiUyVpayPmb1GnWeHDdaNKY=
 github.com/Azure/go-autorest/logger v0.1.0/go.mod h1:oExouG+K6PryycPJfVSxi/koC6LSNgds39diKLz7Vrc=


### PR DESCRIPTION
Refine the error judgment logic.
distinguish ListPods isNotFound error to other errors.
because of the
`log.Warnf("WARNING: No Running Pods found for %s: %s\n", selector, err.Error())`
i think use `errors.IsNotFound(err)` is better.
