### PR TITLE
MOD:remove the pod get in range pods

### DIFF
--- a/cmd/kubefwd/services/services.go
+++ b/cmd/kubefwd/services/services.go
@@ -320,12 +320,6 @@ func fwdServices(opts FwdServiceOpts) error {
 						}
 					}
 
-					_, err = opts.ClientSet.CoreV1().Pods(pod.Namespace).Get(pod.Name, metav1.GetOptions{})
-					if err != nil {
-						log.Warnf("WARNING: Error getting pod: %s\n", err.Error())
-						break
-					}
-
 					serviceHostName := svc.Name
 
 					if podName {


### PR DESCRIPTION
Does it make sense to determine if a pod exists when traversing the pods_item data read from the service?
or other reason to determine if the pod exists or not here?
i think delete this code can clean the code.
PTAL, thanks!