### PR TITLE
FIX:fix the headless service forward twice bug

### DIFF
--- a/cmd/kubefwd/services/services.go
+++ b/cmd/kubefwd/services/services.go
@@ -408,10 +408,12 @@ func fwdServices(opts FwdServiceOpts) error {
 			}
 		}
 
-		podLoop(pods.Items[:1], false)
-
+		// headless service portforward all pods.
+		// normal service portforward the first pod.
 		if svc.Spec.ClusterIP == "None" {
 			podLoop(pods.Items, true)
+		} else {
+			podLoop([]v1.Pod{pods.Items[0]}, false)
 		}
 
 	}


### PR DESCRIPTION
hot fix the headless service forward twice bug.

test in k8s v1.16.0 

---
before
**INFO[15:56:10] Forwarding: nginx1:80 to pod nginx-deployment-5cdfb5fc49-b44j2:80 
INFO[15:56:10] Forwarding: nginx-deployment-5cdfb5fc49-b44j2.nginx1:80 to pod nginx-deployment-5cdfb5fc49-b44j2:80 
INFO[15:56:10] Forwarding: nginx-deployment-5cdfb5fc49-dfhvs.nginx1:80 to pod nginx-deployment-5cdfb5fc49-dfhvs:80** 
```
➜  kubefwd git:(master) sudo go run ./cmd/kubefwd/kubefwd.go svc
INFO[15:56:10]  _          _           __             _     
INFO[15:56:10] | | ___   _| |__   ___ / _|_      ____| |    
INFO[15:56:10] | |/ / | | | '_ \ / _ \ |_\ \ /\ / / _  |    
INFO[15:56:10] |   <| |_| | |_) |  __/  _|\ V  V / (_| |    
INFO[15:56:10] |_|\_\\__,_|_.__/ \___|_|   \_/\_/ \__,_|    
INFO[15:56:10]                                              
INFO[15:56:10] Version 0.0.0                                
INFO[15:56:10] https://github.com/txn2/kubefwd              
INFO[15:56:10]                                              
INFO[15:56:10] Press [Ctrl-C] to stop forwarding.           
INFO[15:56:10] 'cat /etc/hosts' to see all host entries.    
INFO[15:56:10] Loaded hosts file /etc/hosts                 
INFO[15:56:10] Hostfile management: Original hosts backup already exists at /Users/calmkart/hosts.original 
WARN[15:56:10] WARNING: No Pod selector for service kubernetes in default on cluster . 
INFO[15:56:10] Forwarding: nginx:80 to pod nginx-deployment-5cdfb5fc49-b44j2:80 
INFO[15:56:10] Forwarding: nginx1:80 to pod nginx-deployment-5cdfb5fc49-b44j2:80 
INFO[15:56:10] Forwarding: nginx-deployment-5cdfb5fc49-b44j2.nginx1:80 to pod nginx-deployment-5cdfb5fc49-b44j2:80 
INFO[15:56:10] Forwarding: nginx-deployment-5cdfb5fc49-dfhvs.nginx1:80 to pod nginx-deployment-5cdfb5fc49-dfhvs:80 
INFO[15:56:10] Saving hosts file                            
INFO[15:56:41] Stopped forwarding nginx in default.         
INFO[15:56:41] Stopped forwarding nginx-deployment-5cdfb5fc49-b44j2.nginx1 in default. 
INFO[15:56:41] Stopped forwarding nginx1 in default.        
INFO[15:56:41] Stopped forwarding nginx-deployment-5cdfb5fc49-dfhvs.nginx1 in default. 
INFO[15:56:41] Done... 
```

after
```
➜  kubefwd git:(hotfix) sudo go run ./cmd/kubefwd/kubefwd.go svc                      
INFO[16:16:09]  _          _           __             _     
INFO[16:16:09] | | ___   _| |__   ___ / _|_      ____| |    
INFO[16:16:09] | |/ / | | | '_ \ / _ \ |_\ \ /\ / / _  |    
INFO[16:16:09] |   <| |_| | |_) |  __/  _|\ V  V / (_| |    
INFO[16:16:09] |_|\_\\__,_|_.__/ \___|_|   \_/\_/ \__,_|    
INFO[16:16:09]                                              
INFO[16:16:09] Version 0.0.0                                
INFO[16:16:09] https://github.com/txn2/kubefwd              
INFO[16:16:09]                                              
INFO[16:16:09] Press [Ctrl-C] to stop forwarding.           
INFO[16:16:09] 'cat /etc/hosts' to see all host entries.    
INFO[16:16:09] Loaded hosts file /etc/hosts                 
INFO[16:16:09] Hostfile management: Original hosts backup already exists at /Users/calmkart/hosts.original 
WARN[16:16:09] WARNING: No Pod selector for service kubernetes in default on cluster . 
INFO[16:16:09] Forwarding: nginx:80 to pod nginx-deployment-5cdfb5fc49-b44j2:80 
INFO[16:16:09] Forwarding: nginx-deployment-5cdfb5fc49-b44j2.nginx1:80 to pod nginx-deployment-5cdfb5fc49-b44j2:80 
INFO[16:16:09] Forwarding: nginx-deployment-5cdfb5fc49-dfhvs.nginx1:80 to pod nginx-deployment-5cdfb5fc49-dfhvs:80 
INFO[16:16:09] Saving hosts file                            
INFO[16:16:26] Stopped forwarding nginx in default.         
INFO[16:16:26] Stopped forwarding nginx-deployment-5cdfb5fc49-b44j2.nginx1 in default. 
INFO[16:16:26] Stopped forwarding nginx-deployment-5cdfb5fc49-dfhvs.nginx1 in default. 
INFO[16:16:26] Done...
```
