### PR TITLE
Correct/universal way to detect if we're using an administrator windows shell

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,11 @@ go 1.13
 
 require (
 	github.com/elazarl/goproxy v0.0.0-20181111060418-2ce16c963a8a // indirect
+	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5
 	github.com/txn2/txeh v1.2.1
+	golang.org/x/sys v0.0.0-20191115151921-52ab43148777
 	k8s.io/api v0.0.0-20191108065827-59e77acf588f
 	k8s.io/apimachinery v0.0.0-20191108065633-c18f71bf2947
 	k8s.io/cli-runtime v0.0.0-20191108072024-9fe36560f3af

--- a/go.sum
+++ b/go.sum
@@ -287,6 +287,8 @@ golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456 h1:ng0gs1AKnRRuEMZoTLLlbOd+C17zUDepwGQBb/n+JVg=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191115151921-52ab43148777 h1:wejkGHRTr38uaKRqECZlsCsJ1/TGxIyFbH32x5zUdu4=
+golang.org/x/sys v0.0.0-20191115151921-52ab43148777/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pkg/utils/root.go
+++ b/pkg/utils/root.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 /*
 Copyright 2018 Craig Johnston <cjimti@gmail.com>
 
@@ -14,3 +16,29 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 package utils
+
+import (
+	"os/exec"
+	"strconv"
+)
+
+// CheckRoot determines if we have administrative privileges.
+func CheckRoot() (bool, error) {
+	cmd := exec.Command("id", "-u")
+
+	output, err := cmd.Output()
+	if err != nil {
+		return false, err
+	}
+
+	i, err := strconv.Atoi(string(output[:len(output)-1]))
+	if err != nil {
+		return false, err
+	}
+
+	if i == 0 {
+		return true, nil
+	}
+
+	return false, nil
+}

--- a/pkg/utils/root_windows.go
+++ b/pkg/utils/root_windows.go
@@ -1,0 +1,56 @@
+// +build windows
+
+/*
+Copyright 2018 Craig Johnston <cjimti@gmail.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package utils
+
+import (
+	"github.com/pkg/errors"
+	"golang.org/x/sys/windows"
+)
+
+// CheckRoot determines if we have administrative privileges.
+// Ref: https://coolaj86.com/articles/golang-and-windows-and-admins-oh-my/
+func CheckRoot() (bool, error) {
+	var sid *windows.SID
+
+	// Although this looks scary, it is directly copied from the
+	// official windows documentation. The Go API for this is a
+	// direct wrap around the official C++ API.
+	// See https://docs.microsoft.com/en-us/windows/desktop/api/securitybaseapi/nf-securitybaseapi-checktokenmembership
+	err := windows.AllocateAndInitializeSid(
+		&windows.SECURITY_NT_AUTHORITY,
+		2,
+		windows.SECURITY_BUILTIN_DOMAIN_RID,
+		windows.DOMAIN_ALIAS_RID_ADMINS,
+		0, 0, 0, 0, 0, 0,
+		&sid)
+	if err != nil {
+		return false, errors.Errorf("sid error: %s", err)
+	}
+
+	// This appears to cast a null pointer so I'm not sure why this
+	// works, but this guy says it does and it Works for Me™:
+	// https://github.com/golang/go/issues/28804#issuecomment-438838144
+	token := windows.Token(0)
+
+	member, err := token.IsMember(sid)
+	if err != nil {
+		return false, errors.Errorf("token membership error: %s", err)
+	}
+
+	return member, nil
+}


### PR DESCRIPTION
Why: the old way of accessing "\\\\.\\PHYSICALDRIVE0" may not work on
every system, because.. what if I don't have that folder? (clearly my case :D )

Ref for the new way: https://github.com/golang/go/issues/28804