### PR TITLE
Refactoring: Refactored code, added watch service functionality, fixed several bugs, added a set of mainline tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ Check out the [releases](https://github.com/txn2/kubefwd/releases) section on Gi
 ## Usage
 
 Forward all services for the namespace `the-project`. Kubefwd finds the first Pod associated with each Kubernetes service found in the Namespace and port forwards it based on the Service spec to a local IP  address and port. A domain name is added to your /etc/hosts file pointing to the local IP.
+### Update
+Forwarding of headlesss Service is currently supported, Kubefwd forward all Pods for headless service;
+
+At the same time, the namespace-level service monitoring is supported. When a new service is created or the old service is deleted under the namespace, kubefwd can automatically start/end forwarding.
 ```bash
 sudo kubefwd svc -n the-project
 ```

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Forward all services for the namespace `the-project`. Kubefwd finds the first Po
 ### Update
 Forwarding of headlesss Service is currently supported, Kubefwd forward all Pods for headless service;
 
-At the same time, the namespace-level service monitoring is supported. When a new service is created or the old service is deleted under the namespace, kubefwd can automatically start/end forwarding.
+At the same time, the namespace-level service monitoring is supported. When a new service is created or the old service is deleted under the namespace, kubefwd can automatically start/end forwarding; Supports Pod-level forwarding monitoring. When the forwarded Pod is deleted (such as updating the deployment, etc.), the forwarding of the service to which the pod belongs is automatically restarted;
 ```bash
 sudo kubefwd svc -n the-project
 ```

--- a/README_CN.md
+++ b/README_CN.md
@@ -84,6 +84,11 @@ docker exec the-project curl -s elasticsearch:9200
 ## 用法
 
 转发namespace `the-project`下的所有服务。 Kubefwd找到Kubernetess集群中，该namespace下对应的Service端口匹配的第一个Pod，并将其转发到本地IP地址和端口。同时service的域名将被添加到本地的 hosts文件中。
+
+### 更新 
+当前已支持headlesss Service的转发,Kubefwd将转发所有headlesss Service的Pod;
+
+同时支持namespace级服务监听,当namespace下有新Service创建或旧Service删除时,Kubefwd能够自动完成转发/结束转发;
 ```bash
 sudo kubefwd svc -n the-project
 ```

--- a/README_CN.md
+++ b/README_CN.md
@@ -88,7 +88,7 @@ docker exec the-project curl -s elasticsearch:9200
 ### 更新 
 当前已支持headlesss Service的转发,Kubefwd将转发所有headlesss Service的Pod;
 
-同时支持namespace级服务监听,当namespace下有新Service创建或旧Service删除时,Kubefwd能够自动完成转发/结束转发;
+同时支持namespace级服务监听,当namespace下有新Service创建或旧Service删除时,Kubefwd能够自动完成转发/结束转发;支持Pod级转发监听,当转发的Pod被删除时(如更新deployment等情况),自动重启该pod所属Service的转发;
 ```bash
 sudo kubefwd svc -n the-project
 ```

--- a/cmd/kubefwd/services/services.go
+++ b/cmd/kubefwd/services/services.go
@@ -342,9 +342,10 @@ func (opts *FwdServiceOpts) ForwardService(svcName string, svcNamespace string) 
 		return
 	}
 
-	// headless service portforward all pods.
-	// normal service portforward the first pod.
+	// normal service portforward the first pod as service name.
+	// headless service not only forward first Pod as service name, but also portforward all pods.
 	if svc.Spec.ClusterIP == "None" {
+		opts.ForwardFirstPodInService(pods, svc)
 		opts.ForwardAllPodInService(pods, svc)
 	} else {
 		opts.ForwardFirstPodInService(pods, svc)

--- a/cmd/kubefwd/services/services.go
+++ b/cmd/kubefwd/services/services.go
@@ -441,6 +441,7 @@ func (opts *FwdServiceOpts) LoopPodToForward(pods []v1.Pod, podName bool, svc *v
 				Config:            opts.ClientConfig,
 				ClientSet:         opts.ClientSet,
 				RESTClient:        opts.RESTClient,
+				ServiceOperator:   opts,
 				Context:           opts.Context,
 				Namespace:         pod.Namespace,
 				Service:           svcName,

--- a/cmd/kubefwd/services/services_test.go
+++ b/cmd/kubefwd/services/services_test.go
@@ -1,0 +1,280 @@
+package services
+
+import (
+	"net/http"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/txn2/kubefwd/pkg/fwdcfg"
+	"github.com/txn2/kubefwd/pkg/fwdhost"
+	"github.com/txn2/kubefwd/pkg/fwdport"
+	"github.com/txn2/kubefwd/pkg/utils"
+	"github.com/txn2/txeh"
+	appsv1 "k8s.io/api/apps/v1"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes"
+)
+
+// plese run it in root permission.
+// test the main pipe line.
+// test will create a nginx service/deployments and portforward it.
+// then test to http get the service.
+func TestMainPipe(t *testing.T) {
+
+	opts := buildFwdServiceOpts(t)
+
+	stopListenCh := make(chan struct{})
+	defer close(stopListenCh)
+	defer deleteTestService(t, opts.ClientSet)
+
+	go opts.StartListen(stopListenCh)
+
+	go testFwd(t, opts.ClientSet, opts.Wg)
+
+	time.Sleep(2 * time.Second)
+	opts.Wg.Wait()
+
+}
+
+// build the FwdServiceOpts struct
+func buildFwdServiceOpts(t *testing.T) *FwdServiceOpts {
+
+	hasRoot, err := utils.CheckRoot()
+
+	if !hasRoot {
+		t.Fatal("Please run test use Root")
+		if err != nil {
+			t.Fatalf("Root check failure: %s", err.Error())
+		}
+	}
+
+	t.Log("Start buildFwdServiceOpts test")
+
+	hostFile, err := txeh.NewHostsDefault()
+	if err != nil {
+		t.Fatalf("Hostfile error: %s", err.Error())
+	}
+
+	_, err = fwdhost.BackupHostFile(hostFile)
+	if err != nil {
+		t.Fatalf("Error backing up hostfile: %s\n", err.Error())
+	}
+
+	// default cfgFilePath is "$HOME/.kube/config" ;
+	// if you want to use other kubeconfig pls change it here ;
+	cfgFilePath := ""
+
+	// create a ConfigGetter
+	configGetter := fwdcfg.NewConfigGetter()
+	// build the ClientConfig
+	rawConfig, err := configGetter.GetClientConfig(cfgFilePath)
+	if err != nil {
+		t.Fatalf("Error in get rawConfig: %s\n", err.Error())
+	}
+
+	// ipC is the class C for the local IP address
+	// increment this for each cluster
+	// ipD is the class D for the local IP address
+	// increment this for each service in each cluster
+	ipC := 27
+	ipD := 1
+
+	stopListenCh := make(chan struct{})
+	defer close(stopListenCh)
+
+	restConfig, err := configGetter.GetRestConfig(cfgFilePath, rawConfig.CurrentContext)
+	if err != nil {
+		t.Fatalf("Error generating REST configuration: %s\n", err.Error())
+	}
+
+	// create the k8s clientSet
+	clientSet, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		t.Fatalf("Error creating k8s clientSet: %s\n", err.Error())
+	}
+
+	// create the k8s RESTclient
+	restClient, err := configGetter.GetRESTClient()
+	if err != nil {
+		t.Fatalf("Error creating k8s RestClient: %s\n", err.Error())
+	}
+	// create the test service
+	createTestService(t, clientSet)
+
+	listOptions := metav1.ListOptions{
+		LabelSelector: "app=kubefwd-test-nginx-service",
+	}
+
+	wg := &sync.WaitGroup{}
+
+	return &FwdServiceOpts{
+		Wg:           wg,
+		ClientSet:    clientSet,
+		Context:      rawConfig.CurrentContext,
+		Namespace:    "default",
+		ListOptions:  listOptions,
+		Hostfile:     &fwdport.HostFileWithLock{Hosts: hostFile},
+		ClientConfig: restConfig,
+		RESTClient:   restClient,
+		ShortName:    true,
+		Remote:       false,
+		IpC:          byte(ipC),
+		IpD:          ipD,
+		ExitOnFail:   exitOnFail,
+		Domain:       domain,
+	}
+}
+
+// create a test nginx service and deployments
+func createTestService(t *testing.T, clientset *kubernetes.Clientset) {
+
+	// create the test nginx deployements
+	// default namespace is "default"
+
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "kubefwd-test-nginx-deployment",
+			Labels: map[string]string{
+				"app": "kubefwd-test-nginx-deployment",
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: int32Ptr(1),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "kubefwd-test-nginx-deployment",
+				},
+			},
+			Template: apiv1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "kubefwd-test-nginx-deployment",
+					},
+				},
+				Spec: apiv1.PodSpec{
+					Containers: []apiv1.Container{
+						{
+							Name:  "nginx",
+							Image: "nginx:1.11.13-alpine",
+							Ports: []apiv1.ContainerPort{
+								{
+									Name:          "http",
+									Protocol:      apiv1.ProtocolTCP,
+									ContainerPort: 80,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := clientset.AppsV1().Deployments("default").Create(deployment)
+	if err != nil {
+		t.Fatalf("Error creating the test nginx deployment: %s\n", err.Error())
+	}
+
+	// create the test nginx service
+	// default namespace is "default"
+	service := &apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "kubefwd-test-nginx-service",
+		},
+		Spec: apiv1.ServiceSpec{
+			Selector: map[string]string{
+				"app": "kubefwd-test-nginx-deployment",
+			},
+			Ports: []apiv1.ServicePort{
+				{
+					Protocol: apiv1.ProtocolTCP,
+					Port:     80,
+					TargetPort: intstr.IntOrString{
+						IntVal: 80,
+					},
+				},
+			},
+		},
+	}
+
+	_, err = clientset.CoreV1().Services("default").Create(service)
+	if err != nil {
+		t.Fatalf("Error creating the test nginx deployment: %s\n", err.Error())
+	}
+	t.Log("Create test nginx service and deployment success")
+}
+
+// delete the test nginx service and deployments
+func deleteTestService(t *testing.T, clientset *kubernetes.Clientset) {
+	clientset.AppsV1().Deployments("default").Delete("kubefwd-test-nginx-deployment", &metav1.DeleteOptions{})
+	clientset.CoreV1().Services("default").Delete("kubefwd-test-nginx-service", &metav1.DeleteOptions{})
+	t.Log("Delete test nginx service and deployment success")
+}
+
+// http get to test if the forward is success
+func testFwd(t *testing.T, clientset *kubernetes.Clientset, wg *sync.WaitGroup) {
+	pod := findFirstPodOfService(t, clientset)
+	if waitPodRunning(t, clientset, pod) {
+		resp, err := http.Get("http://kubefwd-test-nginx-service/")
+		if err != nil {
+			t.Fatalf("Forward Test nginx service faild, http get is err: %s", err.Error())
+		}
+		if resp.StatusCode == 200 {
+			t.Log("Kubefwd PortForward Service success!")
+			os.Exit(0)
+			return
+		}
+	}
+
+}
+
+func findFirstPodOfService(t *testing.T, clientset *kubernetes.Clientset) *apiv1.Pod {
+	pods, err := clientset.CoreV1().Pods("default").List(metav1.ListOptions{
+		LabelSelector: "app=kubefwd-test-nginx-deployment",
+	})
+	if err != nil {
+		t.Fatalf("Error get pod from Service, err: %s", err.Error())
+	}
+	return &pods.Items[0]
+}
+
+func waitPodRunning(t *testing.T, clientset *kubernetes.Clientset, pod *apiv1.Pod) bool {
+
+	if pod.Status.Phase == apiv1.PodRunning {
+		return true
+	}
+
+	watcher, err := clientset.CoreV1().Pods("default").Watch(metav1.SingleObject(pod.ObjectMeta))
+	if err != nil {
+		t.Fatalf("error in create pod watcher, err: %s", err.Error())
+	}
+	RunningChannel := make(chan struct{})
+
+	defer close(RunningChannel)
+
+	go func() {
+		defer watcher.Stop()
+		select {
+		case <-RunningChannel:
+		case <-time.After(time.Second * 330):
+		}
+	}()
+
+	// watcher until the pod status is running
+	for {
+		event := <-watcher.ResultChan()
+		if event.Object != nil {
+			changedPod := event.Object.(*apiv1.Pod)
+			if changedPod.Status.Phase == apiv1.PodRunning {
+				return true
+			}
+		}
+		time.Sleep(time.Second * 3)
+	}
+}
+
+func int32Ptr(i int32) *int32 { return &i }

--- a/go.sum
+++ b/go.sum
@@ -93,6 +93,7 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d h1:3PaI8p3seN09VjbTYC/QWlUZdZ1qS1zGjy7LH2Wt07I=
 github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903 h1:LbsanbbD6LieFkXbj9YNNBupiGHJgFeLpO0j0Fza1h8=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
@@ -125,6 +126,7 @@ github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEo
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 h1:pdN6V1QBWetyv/0+wjACpqVH+eVULgEjkurDLq3goeM=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=

--- a/pkg/fwdport/fwdport.go
+++ b/pkg/fwdport/fwdport.go
@@ -1,42 +1,59 @@
 package fwdport
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
 	"os"
 	"os/signal"
 	"strconv"
+	"sync"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/txn2/kubefwd/pkg/fwdpub"
 	"github.com/txn2/txeh"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
 )
 
-type PortForwardOpts struct {
-	Out        *fwdpub.Publisher
-	Config     *restclient.Config
-	ClientSet  *kubernetes.Clientset
-	RESTClient *restclient.RESTClient
-	Context    string
-	Namespace  string
-	Service    string
-	PodName    string
-	PodPort    string
-	LocalIp    net.IP
-	LocalPort  string
-	Hostfile   *txeh.Hosts
-	ExitOnFail bool
-	ShortName  bool
-	Remote     bool
-	Domain     string
+type HostFileWithLock struct {
+	Hosts *txeh.Hosts
+	sync.Mutex
 }
 
-func PortForward(pfo *PortForwardOpts) error {
+type HostsParams struct {
+	localServiceName string
+	nsServiceName    string
+	fullServiceName  string
+}
+
+type PortForwardOpts struct {
+	Out         *fwdpub.Publisher
+	Config      *restclient.Config
+	ClientSet   *kubernetes.Clientset
+	RESTClient  *restclient.RESTClient
+	Context     string
+	Namespace   string
+	Service     string
+	PodName     string
+	PodPort     string
+	LocalIp     net.IP
+	LocalPort   string
+	Hostfile    *HostFileWithLock
+	ExitOnFail  bool
+	ShortName   bool
+	Remote      bool
+	Domain      string
+	HostsParams *HostsParams
+	stopSignals chan os.Signal
+}
+
+func (pfo *PortForwardOpts) PortForward() error {
 
 	transport, upgrader, err := spdy.RoundTripperFor(pfo.Config)
 	if err != nil {
@@ -65,80 +82,25 @@ func PortForward(pfo *PortForwardOpts) error {
 
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, os.Interrupt)
+	pfo.stopSignals = signals
 	defer signal.Stop(signals)
 
 	localNamedEndPoint := fmt.Sprintf("%s:%s", pfo.Service, pfo.LocalPort)
 
-	localServiceName := pfo.Service
-	nsServiceName := pfo.Service + "." + pfo.Namespace
-	fullServiceName := fmt.Sprintf("%s.%s.svc.cluster.local", pfo.Service, pfo.Namespace)
-
-	if pfo.Remote {
-		fullServiceName = fmt.Sprintf("%s.%s.svc.cluster.%s", pfo.Service, pfo.Namespace, pfo.Context)
-
-		pfo.Hostfile.RemoveHost(fullServiceName)
-		if pfo.Domain != "" {
-			pfo.Hostfile.AddHost(pfo.LocalIp.String(), pfo.Service+"."+pfo.Domain)
-		}
-		pfo.Hostfile.AddHost(pfo.LocalIp.String(), pfo.Service)
-
-	} else {
-
-		if pfo.ShortName {
-			if pfo.Domain != "" {
-				pfo.Hostfile.RemoveHost(localServiceName + "." + pfo.Domain)
-				pfo.Hostfile.AddHost(pfo.LocalIp.String(), localServiceName+"."+pfo.Domain)
-			}
-			pfo.Hostfile.RemoveHost(localServiceName)
-			pfo.Hostfile.AddHost(pfo.LocalIp.String(), localServiceName)
-		}
-
-		pfo.Hostfile.RemoveHost(fullServiceName)
-		pfo.Hostfile.AddHost(pfo.LocalIp.String(), fullServiceName)
-		if pfo.Domain != "" {
-			pfo.Hostfile.RemoveHost(nsServiceName + "." + pfo.Domain)
-			pfo.Hostfile.AddHost(pfo.LocalIp.String(), nsServiceName+"."+pfo.Domain)
-		}
-		pfo.Hostfile.RemoveHost(nsServiceName)
-		pfo.Hostfile.AddHost(pfo.LocalIp.String(), nsServiceName)
-
-	}
-
-	cleanupHostfile := func() {
-		// other applications or process may have written to /etc/hosts
-		// since it was originally updated.
-		err := pfo.Hostfile.Reload()
-		if err != nil {
-			log.Error("Unable to reload /etc/hosts: " + err.Error())
-			return
-		}
-
-		if pfo.Remote == false {
-			if pfo.Domain != "" {
-				pfo.Hostfile.RemoveHost(localServiceName + "." + pfo.Domain)
-				pfo.Hostfile.RemoveHost(nsServiceName + "." + pfo.Domain)
-			}
-			pfo.Hostfile.RemoveHost(localServiceName)
-			pfo.Hostfile.RemoveHost(nsServiceName)
-		}
-		pfo.Hostfile.RemoveHost(fullServiceName)
-
-		err = pfo.Hostfile.Save()
-		if err != nil {
-			log.Errorf("Error saving /etc/hosts: %s\n", err.Error())
-		}
-	}
+	pfo.BuildTheHostsParams()
+	pfo.AddHosts()
 
 	go func() {
 		<-signals
 		if stopChannel != nil {
-			cleanupHostfile()
+			pfo.removeHosts()
 			close(stopChannel)
 		}
 	}()
 
 	p := pfo.Out.MakeProducer(localNamedEndPoint)
 
+	fmt.Printf("%+v\r\n", *req.URL())
 	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, "POST", req.URL())
 
 	var address []string
@@ -150,17 +112,136 @@ func PortForward(pfo *PortForwardOpts) error {
 
 	fw, err := portforward.NewOnAddresses(dialer, address, fwdPorts, stopChannel, readyChannel, &p, &p)
 	if err != nil {
-		signal.Stop(signals)
-		cleanupHostfile()
+		pfo.Stop()
+		return err
+	}
+
+	err = pfo.WaitForPodRunning()
+	if err != nil {
+		pfo.Stop()
 		return err
 	}
 
 	err = fw.ForwardPorts()
 	if err != nil {
-		signal.Stop(signals)
-		cleanupHostfile()
+		pfo.Stop()
 		return err
 	}
 
 	return nil
+}
+
+// this method to build the HostsParams
+func (pfo *PortForwardOpts) BuildTheHostsParams() {
+	pfo.HostsParams = &HostsParams{}
+	localServiceName := pfo.Service
+	nsServiceName := pfo.Service + "." + pfo.Namespace
+	fullServiceName := fmt.Sprintf("%s.%s.svc.cluster.local", pfo.Service, pfo.Namespace)
+	if pfo.Remote {
+		fullServiceName = fmt.Sprintf("%s.%s.svc.cluster.%s", pfo.Service, pfo.Namespace, pfo.Context)
+	}
+	pfo.HostsParams.localServiceName = localServiceName
+	pfo.HostsParams.nsServiceName = nsServiceName
+	pfo.HostsParams.fullServiceName = fullServiceName
+	return
+}
+
+// this method to add hosts obj in /etc/hosts
+func (pfo *PortForwardOpts) AddHosts() {
+
+	pfo.Hostfile.Lock()
+	if pfo.Remote {
+
+		pfo.Hostfile.Hosts.RemoveHost(pfo.HostsParams.fullServiceName)
+		if pfo.Domain != "" {
+			pfo.Hostfile.Hosts.AddHost(pfo.LocalIp.String(), pfo.Service+"."+pfo.Domain)
+		}
+		pfo.Hostfile.Hosts.AddHost(pfo.LocalIp.String(), pfo.Service)
+
+	} else {
+
+		if pfo.ShortName {
+			if pfo.Domain != "" {
+				pfo.Hostfile.Hosts.RemoveHost(pfo.HostsParams.localServiceName + "." + pfo.Domain)
+				pfo.Hostfile.Hosts.AddHost(pfo.LocalIp.String(), pfo.HostsParams.localServiceName+"."+pfo.Domain)
+			}
+			pfo.Hostfile.Hosts.RemoveHost(pfo.HostsParams.localServiceName)
+			pfo.Hostfile.Hosts.AddHost(pfo.LocalIp.String(), pfo.HostsParams.localServiceName)
+		}
+
+		pfo.Hostfile.Hosts.RemoveHost(pfo.HostsParams.fullServiceName)
+		pfo.Hostfile.Hosts.AddHost(pfo.LocalIp.String(), pfo.HostsParams.fullServiceName)
+		if pfo.Domain != "" {
+			pfo.Hostfile.Hosts.RemoveHost(pfo.HostsParams.nsServiceName + "." + pfo.Domain)
+			pfo.Hostfile.Hosts.AddHost(pfo.LocalIp.String(), pfo.HostsParams.nsServiceName+"."+pfo.Domain)
+		}
+		pfo.Hostfile.Hosts.RemoveHost(pfo.HostsParams.nsServiceName)
+		pfo.Hostfile.Hosts.AddHost(pfo.LocalIp.String(), pfo.HostsParams.nsServiceName)
+
+	}
+	err := pfo.Hostfile.Hosts.Save()
+	if err != nil {
+		log.Error("Error saving hosts file", err)
+	}
+	pfo.Hostfile.Unlock()
+	return
+}
+
+// this method to remove hosts obj in /etc/hosts
+func (pfo *PortForwardOpts) removeHosts() {
+	// we should lock the pfo.Hostfile here
+	// because sometimes other goroutine write the *txeh.Hosts
+	pfo.Hostfile.Lock()
+	// other applications or process may have written to /etc/hosts
+	// since it was originally updated.
+	err := pfo.Hostfile.Hosts.Reload()
+	if err != nil {
+		log.Error("Unable to reload /etc/hosts: " + err.Error())
+		return
+	}
+
+	if pfo.Remote == false {
+		if pfo.Domain != "" {
+			fmt.Printf("removeHost: %s\r\n", (pfo.HostsParams.localServiceName + "." + pfo.Domain))
+			fmt.Printf("removeHost: %s\r\n", (pfo.HostsParams.nsServiceName + "." + pfo.Domain))
+			pfo.Hostfile.Hosts.RemoveHost(pfo.HostsParams.localServiceName + "." + pfo.Domain)
+			pfo.Hostfile.Hosts.RemoveHost(pfo.HostsParams.nsServiceName + "." + pfo.Domain)
+		}
+		fmt.Printf("removeHost: %s\r\n", pfo.HostsParams.localServiceName)
+		fmt.Printf("removeHost: %s\r\n", pfo.HostsParams.nsServiceName)
+		pfo.Hostfile.Hosts.RemoveHost(pfo.HostsParams.localServiceName)
+		pfo.Hostfile.Hosts.RemoveHost(pfo.HostsParams.nsServiceName)
+	}
+	fmt.Printf("removeHost: %s\r\n", pfo.HostsParams.fullServiceName)
+	pfo.Hostfile.Hosts.RemoveHost(pfo.HostsParams.fullServiceName)
+
+	fmt.Printf("Delete Host And Save !\r\n")
+	err = pfo.Hostfile.Hosts.Save()
+	if err != nil {
+		log.Errorf("Error saving /etc/hosts: %s\n", err.Error())
+	}
+	pfo.Hostfile.Unlock()
+}
+
+// Waiting for the pod running
+func (pfo *PortForwardOpts) WaitForPodRunning() error {
+	// default timetout settings is 5s * 60 == 300s
+	// TODO: change it to watch for pod running
+	for i := 0; i < 60; i++ {
+		pod, err := pfo.ClientSet.CoreV1().Pods(pfo.Namespace).Get(pfo.PodName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if pod.Status.Phase != "running" {
+			time.Sleep(5 * time.Second)
+		} else {
+			return nil
+		}
+	}
+	return errors.New("Error: waiting for pod running time out!")
+}
+
+// this method to stop PortForward for the pfo
+func (pfo *PortForwardOpts) Stop() {
+	signal.Stop(pfo.stopSignals)
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -14,3 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 package utils
+
+import (
+	"sync"
+
+	"github.com/txn2/kubefwd/pkg/fwdport"
+)
+
+var lock sync.Mutex
+
+func ThreadSafeAppend(a []*fwdport.PortForwardOpts, b ...*fwdport.PortForwardOpts) []*fwdport.PortForwardOpts {
+	lock.Lock()
+	c := append(a, b...)
+	lock.Unlock()
+	return c
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -21,11 +21,11 @@ import (
 	"github.com/txn2/kubefwd/pkg/fwdport"
 )
 
-var lock sync.Mutex
+var Lock sync.Mutex
 
 func ThreadSafeAppend(a []*fwdport.PortForwardOpts, b ...*fwdport.PortForwardOpts) []*fwdport.PortForwardOpts {
-	lock.Lock()
+	Lock.Lock()
 	c := append(a, b...)
-	lock.Unlock()
+	Lock.Unlock()
 	return c
 }


### PR DESCRIPTION
for #61 
This pr does the following work:
**1. Refactored the code.**
The code now may be more concise and modular.
**2. Added the list&&watch function of the service.** 
Kubefwd can now automatically find the service creation and deletion under the monitored namespace and automatically start/end the forwarding.
**3. Fixed a number of bugs**
not detailed here.
**4. Added a set of tests for the main pipeline**
**5. Maintain full compatibility with past usage methods without any modification by the user.**

Because it is kept in the same way as in the past, from the user experience, it only increases the automatic/disable automatic monitoring and automatic forwarding/end forwarding of the service. It is a feature enhancement, so I think it can be submitted directly.

But there are still some known and necessary work to be done, as follows

What need to do next:
- [x] 1. Add a Pod monitor when creating a Pod's PortForward. Restart the PortForward process of the corresponding Service when any changes occur. (used by the user to modify the service's deployment, etc.)
- [ ] 2. When you end Kubefwd, delete the local redundant Loopback Interface, otherwise there will be many meaningless local IPs.
- [ ] 3. Currently, Kubefwd does not automatically increase the C segment when the IP D segment reaches 254. It should result in the problem that the same context cannot forward more than 255 service pods. It can be solved by automatically adding the C segment.
- [ ] 4. Add more uni test and e2e test. (I am not very good at this)

Next I will take the time to complete the above unfinished work, especially 1 and 2, which I think is very necessary.

we can run the test in 
```shell
cd cmd/kubefwd/services/ && sudo go test -v -test.run TestMainPipe
```

-----

update:
  todo list 1 is done.
