### PR TITLE
enhancement: After forward, remove lo0 interface alias

### DIFF
--- a/pkg/fwdnet/fwdnet.go
+++ b/pkg/fwdnet/fwdnet.go
@@ -74,3 +74,13 @@ func ReadyInterface(a byte, b byte, c byte, d int, port string) (net.IP, int, er
 
 	return net.IP{}, d, errors.New("unable to find an available IP/Port")
 }
+
+// RemoveInterfaceAlias can remove the Interface alias after port forwarding.
+// if -alias command get err, just print the error and continue.
+func RemoveInterfaceAlias(ip net.IP) {
+	cmd := "ifconfig"
+	args := []string{"lo0", "-alias", ip.String()}
+	if err := exec.Command(cmd, args...).Run(); err != nil {
+		fmt.Println("Cannot ifconfig lo0 -alias " + ip.String() + "\r\n" + err.Error())
+	}
+}

--- a/pkg/fwdport/fwdport.go
+++ b/pkg/fwdport/fwdport.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/txn2/kubefwd/pkg/fwdnet"
 	"github.com/txn2/kubefwd/pkg/fwdpub"
 	"github.com/txn2/txeh"
 	v1 "k8s.io/api/core/v1"
@@ -108,6 +109,7 @@ func (pfo *PortForwardOpts) PortForward() error {
 		close(signalChan)
 		if pfStopChannel != nil {
 			pfo.removeHosts()
+			pfo.removeInterfaceAlias()
 			close(pfStopChannel)
 		}
 	}()
@@ -244,6 +246,10 @@ func (pfo *PortForwardOpts) removeHosts() {
 		log.Errorf("Error saving /etc/hosts: %s\n", err.Error())
 	}
 	pfo.Hostfile.Unlock()
+}
+
+func (pfo *PortForwardOpts) removeInterfaceAlias() {
+	fwdnet.RemoveInterfaceAlias(pfo.LocalIp)
 }
 
 // Waiting for the pod running


### PR DESCRIPTION
from #95 
```
What need to do next:
2. When you end Kubefwd, delete the local redundant Loopback Interface, otherwise there will be many meaningless local IPs.
```
this pr can -alias the interface when the port-forward is done.

test in kubernetes v1.16.0
macos


test step
```
➜  ~ sudo ifconfig lo0
lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> mtu 16384
	options=1203<RXCSUM,TXCSUM,TXSTATUS,SW_TIMESTAMP>
	inet 127.0.0.1 netmask 0xff000000
	inet6 ::1 prefixlen 128
	inet6 fe80::1%lo0 prefixlen 64 scopeid 0x1
	nd6 options=201<PERFORMNUD,DAD>
➜  ~
➜  kubefwd git:(master) sudo go run cmd/kubefwd/kubefwd.go svc
INFO[15:05:03]  _          _           __             _
INFO[15:05:03] | | ___   _| |__   ___ / _|_      ____| |
INFO[15:05:03] | |/ / | | | '_ \ / _ \ |_\ \ /\ / / _  |
INFO[15:05:03] |   <| |_| | |_) |  __/  _|\ V  V / (_| |
INFO[15:05:03] |_|\_\\__,_|_.__/ \___|_|   \_/\_/ \__,_|
INFO[15:05:03]
INFO[15:05:03] Version 0.0.0
INFO[15:05:03] https://github.com/txn2/kubefwd
INFO[15:05:03]
INFO[15:05:03] Press [Ctrl-C] to stop forwarding.
INFO[15:05:03] 'cat /etc/hosts' to see all host entries.
INFO[15:05:03] Loaded hosts file /etc/hosts
INFO[15:05:03] Hostfile management: Original hosts backup already exists at /Users/calmkart/hosts.original
WARN[15:05:03] WARNING: No Pod selector for service kubernetes in default on cluster .
INFO[15:05:03] Forwarding: nginx1:80 to pod nginx-deployment1-75c5577b94-tp7zr:80
INFO[15:05:03] Forwarding: nginx-deployment1-75c5577b94-tp7zr.nginx1:80 to pod nginx-deployment1-75c5577b94-tp7zr:80
INFO[15:05:03] Forwarding: nginx-deployment1-75c5577b94-vcpn5.nginx1:80 to pod nginx-deployment1-75c5577b94-vcpn5:80
INFO[15:05:03] Forwarding: nginx:80 to pod nginx-deployment-5cdfb5fc49-bz6p8:80


then open a new terminal
➜  ~ sudo ifconfig lo0
lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> mtu 16384
	options=1203<RXCSUM,TXCSUM,TXSTATUS,SW_TIMESTAMP>
	inet 127.0.0.1 netmask 0xff000000
	inet6 ::1 prefixlen 128
	inet6 fe80::1%lo0 prefixlen 64 scopeid 0x1
	inet 127.1.27.1 netmask 0xff000000
	inet 127.1.27.2 netmask 0xff000000
	inet 127.1.27.3 netmask 0xff000000
	inet 127.1.27.4 netmask 0xff000000
	nd6 options=201<PERFORMNUD,DAD>

then ctrl+c close the kubefwd

^CWARN[15:05:44] Stopped forwarding nginx in default.
WARN[15:05:44] Stopped forwarding nginx-deployment1-75c5577b94-tp7zr.nginx1 in default.
WARN[15:05:44] Stopped forwarding nginx1 in default.
WARN[15:05:44] Stopped forwarding nginx-deployment1-75c5577b94-vcpn5.nginx1 in default.
INFO[15:05:44] Done...
➜  kubefwd git:(master) sudo ifconfig lo0
lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> mtu 16384
	options=1203<RXCSUM,TXCSUM,TXSTATUS,SW_TIMESTAMP>
	inet 127.0.0.1 netmask 0xff000000
	inet6 ::1 prefixlen 128
	inet6 fe80::1%lo0 prefixlen 64 scopeid 0x1
	nd6 options=201<PERFORMNUD,DAD>
```