### PR TITLE
FIX: issue #105 increase time sleep to wait for the service wg add

### DIFF
--- a/cmd/kubefwd/services/services.go
+++ b/cmd/kubefwd/services/services.go
@@ -233,7 +233,11 @@ Try:
 		}
 	}
 
-	time.Sleep(2 * time.Second)
+	// for issue #105
+	// increase time sleep here for no pod service
+	// TODO: better way to solve the problem
+	// maybe the wg.Add(1) move to AddServiceHandler and wg.Done() before return?
+	time.Sleep(4 * time.Second)
 
 	wg.Wait()
 


### PR DESCRIPTION
issue #105 

The order of service discovery is uncertain. When a service without a pod is found first, maybe 2 seconds are not enough for other services to be found and wg.Add (1). So it may cause the main program to directly end wg.wait (). 