### PR TITLE
FIX: waiting for pod runnning, watch event.Object bug

### DIFF
--- a/pkg/fwdport/fwdport.go
+++ b/pkg/fwdport/fwdport.go
@@ -299,10 +299,10 @@ func (pfo *PortForwardOpts) WaitForPodRunning(signalsChan chan struct{}) (*v1.Po
 	// watcher until the pod status is running
 	for {
 		event, ok := <-watcher.ResultChan()
-		if !ok {
+		if !ok || event.Type == "ERROR" {
 			break
 		}
-		if event.Object != nil {
+		if event.Object != nil && event.Type == "MODIFIED" {
 			changedPod := event.Object.(*v1.Pod)
 			if changedPod.Status.Phase == v1.PodRunning {
 				return changedPod, nil


### PR DESCRIPTION
for issue #114 

checked the event
```
// Event represents a single event to a watched resource.
// +k8s:deepcopy-gen=true
type Event struct {
	Type EventType

	// Object is:
	//  * If Type is Added or Modified: the new state of the object.
	//  * If Type is Deleted: the state of the object immediately before deletion.
	//  * If Type is Bookmark: the object (instance of a type being watched) where
	//    only ResourceVersion field is set. On successful restart of watch from a
	//    bookmark resourceVersion, client is guaranteed to not get repeat event
	//    nor miss any events.
	//  * If Type is Error: *api.Status is recommended; other types may make sense
	//    depending on context.
	Object runtime.Object
}
```
the function is for waiting for pod running, so "MODIFIED" is ok, and if eventType is "ERROR" we should break and return nil.