### PR TITLE
Bunch of small improvements

### DIFF
--- a/pkg/fwdhost/fwdhost.go
+++ b/pkg/fwdhost/fwdhost.go
@@ -9,10 +9,14 @@ import (
 	"github.com/txn2/txeh"
 )
 
-// BackupHostFile
+// BackupHostFile will write a backup of the pre-modified hostfile to your home directory, if it does not exist already.
 func BackupHostFile(hostfile *txeh.Hosts) (string, error) {
+	homeDirLocation, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
 
-	backupHostsPath := HomeDir() + "/hosts.original"
+	backupHostsPath := homeDirLocation + "/hosts.original"
 	if _, err := os.Stat(backupHostsPath); os.IsNotExist(err) {
 		from, err := os.Open(hostfile.WriteFilePath)
 		if err != nil {
@@ -34,11 +38,4 @@ func BackupHostFile(hostfile *txeh.Hosts) (string, error) {
 	} else {
 		return fmt.Sprintf("Original hosts backup already exists at %s\n", backupHostsPath), nil
 	}
-}
-
-func HomeDir() string {
-	if h := os.Getenv("HOME"); h != "" {
-		return h
-	}
-	return os.Getenv("USERPROFILE") // windows
 }

--- a/pkg/fwdpub/fwdpub.go
+++ b/pkg/fwdpub/fwdpub.go
@@ -17,11 +17,11 @@ func (p *Publisher) MakeProducer(producer string) Publisher {
 }
 
 func (p *Publisher) Write(b []byte) (int, error) {
-	readLine := string(b)
-	strings.TrimSuffix(readLine, "\n")
+	outputString := string(b)
+	outputString = strings.TrimSuffix(outputString, "\n")
 
 	if p.Output {
-		fmt.Printf("Out: %s, %s, %s", p.PublisherName, p.ProducerName, readLine)
+		fmt.Printf("Out: %s, %s, %s", p.PublisherName, p.ProducerName, outputString)
 	}
 	return 0, nil
 }


### PR DESCRIPTION
Hi, I was going through the code in order to debug some issues I've encountered and to understand a bit how everything works. I made some small changes and cleanup and added some comments here and there while doing so, which might help others as well:

- I've added a check on startup to ensure you can connect to the k8s cluster and have the necessary rbac permissions to run the tool. Currently if you cannot connect to the cluster it just exits without a message indicating why, which gives no information what the problem is:
```bash
...
INFO[22:41:59] Loaded hosts file /etc/hosts                 
INFO[22:41:59] Hostfile management: Original hosts backup already exists at /Users/mhindery/hosts.original 
INFO[22:42:03] Done...                                      
Mathieus-MacBook-Pro:kubefwd mhindery$ 
```
With the change here, it will exit with a fatal-level message:
```bash
...
INFO[22:43:36] Loaded hosts file /etc/hosts                 
INFO[22:43:36] Hostfile management: Original hosts backup already exists at /Users/mhindery/hosts.original 
FATA[22:44:06] Error connecting to k8s cluster: Get "https://<redacted>/version?timeout=32s": dial tcp <redacted>:443: i/o timeout 
exit status 1
Mathieus-MacBook-Pro:kubefwd mhindery$ 
```
If people have very granular rbac permissions set up, where they have only permission for specific services instead of on the whole namespace (which you can select with the label selector using kubefwd), this check won't suffice. So perhaps it should be possible to disable the check via a cmd flag? I think for the large majority of users, this should be an improvement.
- The custom domain added to hosts entries is the same for every entry, and currently prints it out for every service. I've changed this to print this out once at startup instead.
- The event handlers for adding/removing services receive a service object already. Currently every time these are invoking the (un)forwardservice functions, an extra call to obtain this service object is performed, while you already received it. I changed it to pass through that service object instead.
- Use the built-in method of Go to get the user home directory (https://golang.org/pkg/os/#UserHomeDir)
- Some docstring additions
- Fixed some linting errors that popped up