### PR TITLE
Support wildcard namespace selection

### DIFF
--- a/cmd/kubefwd/kubefwd.go
+++ b/cmd/kubefwd/kubefwd.go
@@ -45,7 +45,8 @@ func newRootCmd() *cobra.Command {
 			"  kubefwd svc -n the-project\n" +
 			"  kubefwd svc -n the-project -l env=dev,component=api\n" +
 			"  kubefwd svc -n default -l \"app in (ws, api)\"\n" +
-			"  kubefwd svc -n default -n the-project\n",
+			"  kubefwd svc -n default -n the-project\n" +
+			"  kubefwd svc -r \"^external.*\"\n",
 		Long: globalUsage,
 	}
 

--- a/cmd/kubefwd/services/services.go
+++ b/cmd/kubefwd/services/services.go
@@ -17,8 +17,8 @@ package services
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -46,6 +46,7 @@ import (
 )
 
 var namespaces []string
+var regexNamespace string
 var contexts []string
 var exitOnFail bool
 var verbose bool
@@ -61,7 +62,8 @@ func init() {
 
 	Cmd.Flags().StringP("kubeconfig", "c", "", "absolute path to a kubectl config file")
 	Cmd.Flags().StringSliceVarP(&contexts, "context", "x", []string{}, "specify a context to override the current context")
-	Cmd.Flags().StringSliceVarP(&namespaces, "namespace", "n", []string{}, "Specify a namespace. Specify multiple namespaces by duplicating this argument. Use \"*\" (including the quotes) to use all-but-system (e.g. kube-system) namespaces.")
+	Cmd.Flags().StringSliceVarP(&namespaces, "namespace", "n", []string{}, "Specify a namespace. Specify multiple namespaces by duplicating this argument.")
+	Cmd.Flags().StringVarP(&regexNamespace, "regex-namespace", "r", "", "Specify a regex to use all namespaces matching it. Can be used in conjunction with explicit namespaces given using the --namespace/-n flag(s).")
 	Cmd.Flags().StringP("selector", "l", "", "Selector (label query) to filter on; supports '=', '==', and '!=' (e.g. -l key1=value1,key2=value2).")
 	Cmd.Flags().BoolVarP(&exitOnFail, "exitonfailure", "", false, "Exit(1) on failure. Useful for forcing a container restart.")
 	Cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Verbose output.")
@@ -77,12 +79,13 @@ var Cmd = &cobra.Command{
 	Example: "  kubefwd svc -n the-project\n" +
 		"  kubefwd svc -n the-project -l app=wx,component=api\n" +
 		"  kubefwd svc -n default -n the-project\n" +
+		"  kubefwd svc -r \"^external.*\"\n" +
 		"  kubefwd svc -n default -d internal.example.com\n" +
 		"  kubefwd svc -n the-project -x prod-cluster\n",
 	Run: runCmd,
 }
 
-// checkConnection tests if you can connect to the cluster in your config
+// checkConnectivity tests if you can connect to the cluster in your config
 func checkConnectivity(clientSet *kubernetes.Clientset) error {
 	_, err := clientSet.Discovery().ServerVersion()
 	if err != nil {
@@ -254,23 +257,25 @@ Try:
 		}
 		log.Infof("Succesfully connected context: %v", ctx)
 
-		// If a wildcard namespace selector was given, query for all the namespaces and use all non-kube-internal ones
-		if len(namespaces) == 1 && namespaces[0] == "*" {
+		// If a regex namespace expression was given, query for the available namespaces in the cluster,
+		// and add all of the matching ones to the list of namespaces to proxy for
+		if regexNamespace != "" {
+			reNS := regexp.MustCompile(regexNamespace)
+
 			// Query for the names of all namespaces
 			namespacesList, err := clientSet.CoreV1().Namespaces().List(metav1.ListOptions{})
 			if err != nil {
 				log.Fatalf("Error obtaining namespaces from cluster: %s\n", err.Error())
 			}
 
-			// Construct list of the ones to use
-			namespaces = nil
+			// Add the matching ones to the list of namespaces to do
 			for _, ns := range namespacesList.Items {
-				if !strings.HasPrefix(ns.Name, "kube-") {
+				if reNS.FindString(ns.Name) == ns.Name {
 					namespaces = append(namespaces, ns.Name)
 				}
 			}
-			log.Infof("Namespaces to forward (via wildcard): %s", namespaces)
 		}
+		log.Infof("Namespaces to forward: %s", namespaces)
 
 		// Permission check on all the namespaces
 		err = checkNamespacePermissions(clientSet, namespaces)


### PR DESCRIPTION
Instead of having to specify all the namespaces, support a wildcard value. This will do portforwarding for all namespaces except the ones beginning with "kube-" as these are internal ones.

I split up the permission check which previously checked both connectivity and namespace permissions, since for the wildcard you need to fetch the list of namespaces, and that falls inbetween being connected to the cluster and having permissions on all namespaces.