### PR TITLE
Startup performance improvements

### DIFF
--- a/cmd/kubefwd/services/services.go
+++ b/cmd/kubefwd/services/services.go
@@ -403,7 +403,7 @@ func (opts *FwdServiceOpts) ForwardService(svc *v1.Service) {
 
 	// normal service portforward the first pod as service name.
 	// headless service not only forward first Pod as service name, but also portforward all pods.
-	if svc.Spec.ClusterIP == "None" || true {
+	if svc.Spec.ClusterIP == "None" {
 		opts.ForwardFirstPodInService(pods, svc)
 		opts.ForwardAllPodInService(pods, svc)
 	} else {

--- a/cmd/kubefwd/services/services.go
+++ b/cmd/kubefwd/services/services.go
@@ -264,7 +264,7 @@ Try:
 					ClientSet:       clientSet,
 					Context:         ctx,
 					Namespace:       namespace,
-					NamespaceIPLock: sync.Mutex{}, // For parallelization of ip handout, each namespace has its own a.b.c.* range
+					NamespaceIPLock: &sync.Mutex{}, // For parallelization of ip handout, each namespace has its own a.b.c.* range
 					ListOptions:     listOptions,
 					Hostfile:        &fwdport.HostFileWithLock{Hosts: hostFile},
 					ClientConfig:    restConfig,
@@ -297,7 +297,7 @@ type FwdServiceOpts struct {
 	ClientSet       *kubernetes.Clientset
 	Context         string
 	Namespace       string
-	NamespaceIPLock sync.Mutex
+	NamespaceIPLock *sync.Mutex
 	ListOptions     metav1.ListOptions
 	Hostfile        *fwdport.HostFileWithLock
 	ClientConfig    *restclient.Config

--- a/cmd/kubefwd/services/services.go
+++ b/cmd/kubefwd/services/services.go
@@ -377,7 +377,7 @@ func (opts *FwdServiceOpts) ForwardService(svc *v1.Service) {
 
 	listOpts := metav1.ListOptions{LabelSelector: selector}
 
-	// Only a single pod is required in this case
+	// Only a single pod (which will be setup for forwarding) is required in this case
 	if svc.Spec.ClusterIP == "None" {
 		listOpts.Limit = 1
 	}

--- a/pkg/fwdnet/fwdnet.go
+++ b/pkg/fwdnet/fwdnet.go
@@ -8,24 +8,26 @@ import (
 	"os/exec"
 	"runtime"
 	"sync"
+
+	log "github.com/sirupsen/logrus"
 )
 
 var addrs []net.Addr
 var initAddresses sync.Once
 
 // getLocalListenAddrs returns the listen addresses for the lo0 interface.
-// It will panic if these could not be determined. TODO: panic ok or other handling?
+// It will exit if these could not be determined.
 func getLocalListenAddrs() []net.Addr {
 	initAddresses.Do(func() {
 		if addrs == nil {
 			iface, err := net.InterfaceByName("lo0")
 			if err != nil {
-				panic(fmt.Sprintf("Could not get lo0 netInterface: %s", err))
+				log.Fatalf("Could not get lo0 netInterface: %s", err)
 			}
 
 			addrs, err = iface.Addrs()
 			if err != nil {
-				panic(fmt.Sprintf("Could not get lo0 listen addresses: %s", err))
+				log.Fatalf("Could not get lo0 listen addresses: %s", err)
 			}
 		}
 	})

--- a/pkg/fwdnet/fwdnet.go
+++ b/pkg/fwdnet/fwdnet.go
@@ -7,7 +7,31 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"sync"
 )
+
+var addrs []net.Addr
+var initAddresses sync.Once
+
+// getLocalListenAddrs returns the listen addresses for the lo0 interface.
+// It will panic if these could not be determined. TODO: panic ok or other handling?
+func getLocalListenAddrs() []net.Addr {
+	initAddresses.Do(func() {
+		if addrs == nil {
+			iface, err := net.InterfaceByName("lo0")
+			if err != nil {
+				panic(fmt.Sprintf("Could not get lo0 netInterface: %s", err))
+			}
+
+			addrs, err = iface.Addrs()
+			if err != nil {
+				panic(fmt.Sprintf("Could not get lo0 listen addresses: %s", err))
+			}
+		}
+	})
+
+	return addrs
+}
 
 // ReadyInterface prepares a local IP address on
 // the loopback interface.
@@ -31,18 +55,8 @@ func ReadyInterface(a byte, b byte, c byte, d int, port string) (net.IP, int, er
 
 		ip = net.IPv4(a, b, c, byte(i))
 
-		iface, err := net.InterfaceByName("lo0")
-		if err != nil {
-			return net.IP{}, i, err
-		}
-
-		addrs, err := iface.Addrs()
-		if err != nil {
-			return net.IP{}, i, err
-		}
-
 		// check the addresses already assigned to the interface
-		for _, addr := range addrs {
+		for _, addr := range getLocalListenAddrs() {
 
 			// found a match
 			if addr.String() == ip.String()+"/8" {


### PR DESCRIPTION
With a decent set of namespaces, services and pods, it takes a while to startup. This is because every namespace and service within is setup sequentially. Every of these loops does [a call to fetch a list of pods](https://github.com/txn2/kubefwd/blob/master/cmd/kubefwd/services/services.go#L378) which can be quite slow (I've seen the same call range from 200ms to several seconds in my setup) and is a bottleneck. If you have some headless services with several pods in them, the startup time of kubefwd is pretty slow (tens of seconds).

I've made a change to do every namespace and every service within in parallel instead of sequentially. The only shared resource I think there is, is the [ip address handout call](https://github.com/txn2/kubefwd/blob/master/cmd/kubefwd/services/services.go#L438), which I've guarded with a lock per namespace for threadsafety. (The handout call itself is fast and not a bottleneck; I mainly needed to fix the bottleneck due to sequentiality of the podlisting calls mentioned above). All other logic seems safe to run in parallel at first sight.

The change leads to a significantly faster startup (between a third and half of the time with my setup on 32 non-headless services across 4 namespaces. With these services as headless ones, the difference is bigger with a few seconds to near a minute of startuptime).