### PR TITLE
Restructuring for stability and usability improvements

### DIFF
--- a/cmd/kubefwd/services/services.go
+++ b/cmd/kubefwd/services/services.go
@@ -17,15 +17,16 @@ package services
 
 import (
 	"fmt"
-	"strconv"
+	"os"
+	"os/signal"
 	"sync"
-	"time"
+	"syscall"
 
 	"github.com/txn2/kubefwd/pkg/fwdcfg"
 	"github.com/txn2/kubefwd/pkg/fwdhost"
-	"github.com/txn2/kubefwd/pkg/fwdnet"
 	"github.com/txn2/kubefwd/pkg/fwdport"
-	"github.com/txn2/kubefwd/pkg/fwdpub"
+	"github.com/txn2/kubefwd/pkg/fwdservice"
+	"github.com/txn2/kubefwd/pkg/fwdsvcregistry"
 	"github.com/txn2/kubefwd/pkg/utils"
 	"github.com/txn2/txeh"
 
@@ -33,36 +34,37 @@ import (
 	"github.com/spf13/cobra"
 	authorizationv1 "k8s.io/api/authorization/v1"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilRuntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 )
 
+// cmdline arguments
 var namespaces []string
+var regexNamespace string
 var contexts []string
 var exitOnFail bool
 var verbose bool
 var domain string
-var AllPortForwardOpts []*fwdport.PortForwardOpts
 
 func init() {
-
 	// override error output from k8s.io/apimachinery/pkg/util/runtime
-	runtime.ErrorHandlers[0] = func(err error) {
+	utilRuntime.ErrorHandlers[0] = func(err error) {
 		log.Errorf("Runtime error: %s", err.Error())
+		fwdsvcregistry.SyncAll()
 	}
 
 	Cmd.Flags().StringP("kubeconfig", "c", "", "absolute path to a kubectl config file")
 	Cmd.Flags().StringSliceVarP(&contexts, "context", "x", []string{}, "specify a context to override the current context")
 	Cmd.Flags().StringSliceVarP(&namespaces, "namespace", "n", []string{}, "Specify a namespace. Specify multiple namespaces by duplicating this argument.")
 	Cmd.Flags().StringP("selector", "l", "", "Selector (label query) to filter on; supports '=', '==', and '!=' (e.g. -l key1=value1,key2=value2).")
-	Cmd.Flags().BoolVarP(&exitOnFail, "exitonfailure", "", false, "Exit(1) on failure. Useful for forcing a container restart.")
 	Cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Verbose output.")
 	Cmd.Flags().StringVarP(&domain, "domain", "d", "", "Append a pseudo domain name to generated host names.")
 
@@ -192,8 +194,8 @@ Try:
 		listOptions.LabelSelector = selector
 	}
 
-	// if no namespaces were specified, check config then
-	// explicitly set one to "default"
+	// if no namespaces were specified via the flags, check config from the k8s context
+	// then explicitly set one to "default"
 	if len(namespaces) < 1 {
 		namespaces = []string{"default"}
 		x := rawConfig.CurrentContext
@@ -220,15 +222,28 @@ Try:
 	ipC := 27
 	ipD := 1
 
-	wg := &sync.WaitGroup{}
-
 	stopListenCh := make(chan struct{})
-	defer close(stopListenCh)
+
+	// Listen for shutdown signal from user
+	go func() {
+		sigint := make(chan os.Signal, 1)
+		signal.Notify(sigint, os.Interrupt, syscall.SIGTERM)
+		defer func() {
+			signal.Stop(sigint)
+		}()
+		<-sigint
+		log.Infof("Received shutdown signal")
+		close(stopListenCh)
+	}()
 
 	// if no context override
 	if len(contexts) < 1 {
 		contexts = append(contexts, rawConfig.CurrentContext)
 	}
+
+	fwdsvcregistry.Init(stopListenCh)
+
+	nsWatchesDone := &sync.WaitGroup{} // We'll wait on this to exit the program. Done() indicates that all namespace watches have shutdown cleanly.
 
 	for i, ctx := range contexts {
 		// k8s REST config
@@ -257,294 +272,149 @@ Try:
 		}
 
 		for ii, namespace := range namespaces {
-			// ShortName field only use short name for the first namespace and context
-			fwdServiceOpts := FwdServiceOpts{
-				Wg:           wg,
-				ClientSet:    clientSet,
-				Context:      ctx,
-				Namespace:    namespace,
-				ListOptions:  listOptions,
-				Hostfile:     &fwdport.HostFileWithLock{Hosts: hostFile},
-				ClientConfig: restConfig,
-				RESTClient:   restClient,
-				ShortName:    i < 1 && ii < 1,
-				Remote:       i > 0,
-				IpC:          byte(ipC),
-				IpD:          ipD,
-				ExitOnFail:   exitOnFail,
-				Domain:       domain,
-			}
-			go fwdServiceOpts.StartListen(stopListenCh)
-
-			ipC = ipC + 1
+			nsWatchesDone.Add(1)
+			go func(ii int, namespace string) {
+				// ShortName field only use short name for the first namespace and context
+				nameSpaceOpts := NamespaceOpts{
+					ClientSet:         clientSet,
+					Context:           ctx,
+					Namespace:         namespace,
+					NamespaceIPLock:   &sync.Mutex{}, // For parallelization of ip handout, each namespace has its own a.b.c.* range
+					ListOptions:       listOptions,
+					Hostfile:          &fwdport.HostFileWithLock{Hosts: hostFile},
+					ClientConfig:      restConfig,
+					RESTClient:        restClient,
+					ShortName:         i < 1 && ii < 1,
+					Remote:            i > 0,
+					IpC:               byte(ipC + ii),
+					IpD:               ipD,
+					Domain:            domain,
+					ManualStopChannel: stopListenCh,
+				}
+				nameSpaceOpts.watchServiceEvents(stopListenCh)
+				nsWatchesDone.Done()
+			}(ii, namespace)
 		}
 	}
 
-	// for issue #105
-	// increase time sleep here for no pod service
-	// TODO: better way to solve the problem
-	// maybe the wg.Add(1) move to AddServiceHandler and wg.Done() before return?
-	time.Sleep(4 * time.Second)
+	nsWatchesDone.Wait()
+	log.Debugf("All namespace watchers are done")
 
-	wg.Wait()
+	// Shutdown all active services
+	<-fwdsvcregistry.Done()
 
-	log.Printf("Done...\n")
+	log.Infof("Clean exit")
 }
 
-type FwdServiceOpts struct {
-	Wg           *sync.WaitGroup
-	ClientSet    *kubernetes.Clientset
-	Context      string
-	Namespace    string
-	ListOptions  metav1.ListOptions
-	Hostfile     *fwdport.HostFileWithLock
-	ClientConfig *restclient.Config
-	RESTClient   *restclient.RESTClient
-	ShortName    bool
-	Remote       bool
-	IpC          byte
-	IpD          int
-	ExitOnFail   bool
-	Domain       string
+type NamespaceOpts struct {
+	ClientSet         *kubernetes.Clientset
+	Context           string
+	Namespace         string
+	NamespaceIPLock   *sync.Mutex
+	ListOptions       metav1.ListOptions
+	Hostfile          *fwdport.HostFileWithLock
+	ClientConfig      *restclient.Config
+	RESTClient        *restclient.RESTClient
+	ShortName         bool
+	Remote            bool
+	IpC               byte
+	IpD               int
+	Domain            string
+	ManualStopChannel chan struct{}
 }
 
-// StartListen sets up event handlers to act on service-related events.
-func (opts *FwdServiceOpts) StartListen(stopListenCh <-chan struct{}) {
-
+// watchServiceEvents sets up event handlers to act on service-related events.
+func (opts *NamespaceOpts) watchServiceEvents(stopListenCh <-chan struct{}) {
+	// Apply filtering
 	optionsModifier := func(options *metav1.ListOptions) {
 		options.FieldSelector = fields.Everything().String()
 		options.LabelSelector = opts.ListOptions.LabelSelector
 	}
-	watchlist := cache.NewFilteredListWatchFromClient(opts.RESTClient, "services", opts.Namespace, optionsModifier)
-	_, controller := cache.NewInformer(watchlist, &v1.Service{}, 0, cache.ResourceEventHandlerFuncs{
-		AddFunc:    opts.AddServiceHandler,
-		DeleteFunc: opts.DeleteServiceHandler,
-		UpdateFunc: opts.UpdateServiceHandler,
-	},
+
+	// Construct the informer object which will query the api server,
+	// and send events to our handler functions
+	// https://engineering.bitnami.com/articles/kubewatch-an-example-of-kubernetes-custom-controller.html
+	_, controller := cache.NewInformer(
+		&cache.ListWatch{
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				optionsModifier(&options)
+				return opts.ClientSet.CoreV1().Services(opts.Namespace).List(options)
+			},
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				options.Watch = true
+				optionsModifier(&options)
+				return opts.ClientSet.CoreV1().Services(opts.Namespace).Watch(options)
+			},
+		},
+		&v1.Service{},
+		0,
+		cache.ResourceEventHandlerFuncs{
+			AddFunc:    opts.AddServiceHandler,
+			DeleteFunc: opts.DeleteServiceHandler,
+			UpdateFunc: opts.UpdateServiceHandler,
+		},
 	)
 
-	stop := make(chan struct{})
-	go controller.Run(stop)
-	defer close(stop)
-
-	<-stopListenCh
+	// Start the informer, blocking call until we receive a stop signal
+	controller.Run(stopListenCh)
+	log.Infof("Stopped watching Service events in namespace %s", opts.Namespace)
 }
 
-// AddServiceHandler is the event handler for when a new service comes in from k8s.
-func (opts *FwdServiceOpts) AddServiceHandler(obj interface{}) {
+// AddServiceHandler is the event handler for when a new service comes in from k8s (the initial list of services will also be coming in using this event for each).
+func (opts *NamespaceOpts) AddServiceHandler(obj interface{}) {
 	svc, ok := obj.(*v1.Service)
 	if !ok {
 		return
 	}
 
-	log.Debugf("Add service %s namespace %s.", svc.Name, svc.Namespace)
+	// Check if service has a valid config to do forwarding
+	selector := labels.Set(svc.Spec.Selector).AsSelector().String()
+	if selector == "" {
+		log.Warnf("WARNING: No Pod selector for service %s.%s, skipping\n", svc.Name, svc.Namespace)
+		return
+	}
 
-	opts.ForwardService(svc)
+	// Define a service to forward
+	svcfwd := &fwdservice.ServiceFWD{
+		ClientSet:        opts.ClientSet,
+		Context:          opts.Context,
+		Namespace:        opts.Namespace,
+		Hostfile:         opts.Hostfile,
+		ClientConfig:     opts.ClientConfig,
+		RESTClient:       opts.RESTClient,
+		ShortName:        opts.ShortName,
+		Remote:           opts.Remote,
+		IpC:              opts.IpC,
+		IpD:              &opts.IpD,
+		Domain:           opts.Domain,
+		PodLabelSelector: selector,
+		NamespaceIPLock:  opts.NamespaceIPLock,
+		Svc:              svc,
+		Headless:         svc.Spec.ClusterIP == "None",
+		PortForwards:     make(map[string]*fwdport.PortForwardOpts),
+		DoneChannel:      make(chan struct{}),
+	}
+
+	// Add the service to out catalog of services being forwarded
+	fwdsvcregistry.Add(svcfwd)
 }
 
 // DeleteServiceHandler is the event handler for when a service gets deleted in k8s.
-func (opts *FwdServiceOpts) DeleteServiceHandler(obj interface{}) {
+func (opts *NamespaceOpts) DeleteServiceHandler(obj interface{}) {
 	svc, ok := obj.(*v1.Service)
 	if !ok {
 		return
 	}
 
-	log.Debugf("Delete service %s namespace %s.", svc.Name, svc.Namespace)
-
-	opts.UnForwardService(svc)
+	// If we are currently forwarding this service, shut it down.
+	fwdsvcregistry.RemoveByName(svc.Name + "." + svc.Namespace)
 }
 
 // UpdateServiceHandler is the event handler to deal with service changes from k8s.
 // It currently does not do anything.
-func (opts *FwdServiceOpts) UpdateServiceHandler(old interface{}, new interface{}) {
+func (opts *NamespaceOpts) UpdateServiceHandler(old interface{}, new interface{}) {
 	key, err := cache.MetaNamespaceKeyFunc(new)
 	if err == nil {
 		log.Printf("update service %s.", key)
 	}
-}
-
-// ForwardService selects one or all pods behind a service, and invokes the forwarding setup for that or those pod(s).
-func (opts *FwdServiceOpts) ForwardService(svc *v1.Service) {
-	set := labels.Set(svc.Spec.Selector)
-	selector := set.AsSelector().String()
-
-	if selector == "" {
-		log.Warnf("WARNING: No Pod selector for service %s in %s on cluster %s.\n", svc.Name, svc.Namespace, svc.ClusterName)
-		return
-	}
-
-	listOpts := metav1.ListOptions{LabelSelector: selector}
-
-	pods, err := opts.ClientSet.CoreV1().Pods(svc.Namespace).List(listOpts)
-
-	if err != nil {
-		if errors.IsNotFound(err) {
-			log.Warnf("WARNING: No Pods found for %s: %s\n", selector, err.Error())
-		} else {
-			log.Warnf("WARNING: Error in List pods for %s: %s\n", selector, err.Error())
-		}
-		return
-	}
-
-	// for issue #99
-	// add this check for the service scale down to 0 situation.
-	// TODO: a better way to do this check.
-	if len(pods.Items) < 1 {
-		log.Warnf("WARNING: No Running Pods returned for service %s in %s on cluster %s.\n", svc.Name, svc.Namespace, svc.ClusterName)
-		return
-	}
-
-	// normal service portforward the first pod as service name.
-	// headless service not only forward first Pod as service name, but also portforward all pods.
-	if svc.Spec.ClusterIP == "None" {
-		opts.ForwardFirstPodInService(pods, svc)
-		opts.ForwardAllPodInService(pods, svc)
-	} else {
-		opts.ForwardFirstPodInService(pods, svc)
-	}
-}
-
-func (opts *FwdServiceOpts) UnForwardService(svc *v1.Service) {
-
-	utils.Lock.Lock()
-	// Search in the PortForwardOpts entries for for this service. If it is currently active,
-	// stop the forwarding and threadSafe delete the PortForward obj.
-	for i := 0; i < len(AllPortForwardOpts); i++ {
-		pfo := AllPortForwardOpts[i]
-		if pfo.NativeServiceName == svc.Name && pfo.Namespace == svc.Namespace {
-			pfo.Stop()
-			AllPortForwardOpts = append(AllPortForwardOpts[:i], AllPortForwardOpts[i+1:]...)
-			i--
-		}
-	}
-	utils.Lock.Unlock()
-}
-
-// LoopPodsToForward starts the portforwarding for each pod
-func (opts *FwdServiceOpts) LoopPodsToForward(pods []v1.Pod, svc *v1.Service) {
-	publisher := &fwdpub.Publisher{
-		PublisherName: "Services",
-		Output:        false,
-	}
-
-	// If multiple pods need to be forwarded, they all get their own host entry
-	includePodNameInHost := len(pods) > 1
-
-	for _, pod := range pods {
-
-		podPort := ""
-		svcName := ""
-
-		localIp, dInc, err := fwdnet.ReadyInterface(127, 1, opts.IpC, opts.IpD, podPort)
-		if err != nil {
-			log.Warnf("WARNING: error readying interface: %s\n", err)
-		}
-		opts.IpD = dInc
-
-		for _, port := range svc.Spec.Ports {
-
-			podPort = port.TargetPort.String()
-			localPort := strconv.Itoa(int(port.Port))
-
-			if _, err := strconv.Atoi(podPort); err != nil {
-				// search a pods containers for the named port
-				if namedPodPort, ok := portSearch(podPort, pod.Spec.Containers); ok {
-					podPort = namedPodPort
-				}
-			}
-
-			serviceHostName := svc.Name
-
-			if includePodNameInHost {
-				serviceHostName = pod.Name + "." + serviceHostName
-			}
-
-			svcName = serviceHostName
-
-			if !opts.ShortName {
-				serviceHostName = serviceHostName + "." + pod.Namespace
-			}
-
-			if opts.Domain != "" {
-				serviceHostName = serviceHostName + "." + opts.Domain
-			}
-
-			if opts.Remote {
-				serviceHostName = fmt.Sprintf("%s.svc.cluster.%s", serviceHostName, opts.Context)
-			}
-
-			log.Debugf("Resolving:    %s to %s\n",
-				serviceHostName,
-				localIp.String(),
-			)
-
-			log.Printf("Port-Forward: %s:%d to pod %s:%s\n",
-				serviceHostName,
-				port.Port,
-				pod.Name,
-				podPort,
-			)
-
-			pfo := &fwdport.PortForwardOpts{
-				Out:               publisher,
-				Config:            opts.ClientConfig,
-				ClientSet:         opts.ClientSet,
-				RESTClient:        opts.RESTClient,
-				ServiceOperator:   opts,
-				Context:           opts.Context,
-				Namespace:         pod.Namespace,
-				Service:           svcName,
-				NativeServiceName: svc.Name,
-				PodName:           pod.Name,
-				PodPort:           podPort,
-				LocalIp:           localIp,
-				LocalPort:         localPort,
-				Hostfile:          opts.Hostfile,
-				ShortName:         opts.ShortName,
-				Remote:            opts.Remote,
-				ExitOnFail:        exitOnFail,
-				Domain:            domain,
-			}
-			AllPortForwardOpts = utils.ThreadSafeAppend(AllPortForwardOpts, pfo)
-
-			opts.Wg.Add(1)
-			go func() {
-				err := pfo.PortForward()
-				if err != nil {
-					log.Printf("ERROR: %s", err.Error())
-				}
-
-				log.Warnf("Stopped forwarding %s in %s.", pfo.Service, pfo.Namespace)
-
-				opts.Wg.Done()
-			}()
-
-		}
-
-	}
-}
-
-// ForwardFirstPodInService will set up portforwarding to a single pod of the service.
-// A single entry for the service will be added to the hosts file.
-func (opts *FwdServiceOpts) ForwardFirstPodInService(pods *v1.PodList, svc *v1.Service) {
-	opts.LoopPodsToForward([]v1.Pod{pods.Items[0]}, svc)
-}
-
-// ForwardAllPodInService will set up portforwarding for each pod in the service. A separate entry
-// for every pod will thus be added to the hosts file and individual pods can be addressed.
-func (opts *FwdServiceOpts) ForwardAllPodInService(pods *v1.PodList, svc *v1.Service) {
-	opts.LoopPodsToForward(pods.Items, svc)
-}
-
-func portSearch(portName string, containers []v1.Container) (string, bool) {
-
-	for _, container := range containers {
-		for _, cp := range container.Ports {
-			if cp.Name == portName {
-				return fmt.Sprint(cp.ContainerPort), true
-			}
-		}
-	}
-
-	return "", false
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/elazarl/goproxy v0.0.0-20181111060418-2ce16c963a8a // indirect
+	github.com/pingcap/errors v0.11.4
 	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -188,6 +188,7 @@ github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQ
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
+github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
@@ -348,10 +349,13 @@ k8s.io/api v0.0.0-20191108065827-59e77acf588f h1:ZTXCVdYGBbAblNUJ5B19ztoy6WHMNrP
 k8s.io/api v0.0.0-20191108065827-59e77acf588f/go.mod h1:uQDmBYHoPSuhbg8FGTRzrOdaNqLiws/LAtBrHv0kN5U=
 k8s.io/apimachinery v0.0.0-20191108065633-c18f71bf2947 h1:f3H3Rf7KD9fjmmbIMwxBye3ctEuXnbskaX/l1xy+68E=
 k8s.io/apimachinery v0.0.0-20191108065633-c18f71bf2947/go.mod h1:nEP/6rwhzfljWYGVS6pfyES3ipZTR19vzMnSM+ur3ho=
+k8s.io/apimachinery v0.18.3 h1:pOGcbVAhxADgUYnjS08EFXs9QMl8qaH5U4fr5LGUrSk=
 k8s.io/cli-runtime v0.0.0-20191108072024-9fe36560f3af h1:lWKOjXCJ/PVS6pJvHcDs1RyG47Zq+WFjs/DvK1CLNP0=
 k8s.io/cli-runtime v0.0.0-20191108072024-9fe36560f3af/go.mod h1:gS0U9D/luQtMGiNl4Y5IhcrmW+xwbuTiqPLv+plcW20=
 k8s.io/client-go v0.0.0-20191108070106-f8f007fd456c h1:TaCF427jtkNsXDzSNXOFFox1DePy6WX9Nf8E1vriHys=
 k8s.io/client-go v0.0.0-20191108070106-f8f007fd456c/go.mod h1:D6hkzmLWI59QLvDVt8tlD5J2X1YDjcattS6vw8lP1hc=
+k8s.io/client-go v1.5.1 h1:XaX/lo2/u3/pmFau8HN+sB5C/b4dc4Dmm2eXjBH4p1E=
+k8s.io/client-go v11.0.0+incompatible h1:LBbX2+lOwY9flffWlJM7f1Ct8V2SRNiMRDFeiwnJo9o=
 k8s.io/code-generator v0.0.0-20191108065441-3c1097069dc3/go.mod h1:OJTI2RPXj6kq4bfFqT1JrTEC1S4toTWinGOm1O8jUuY=
 k8s.io/component-base v0.0.0-20191108070619-4b9966ca0181 h1:dAWmrp5YxoO7PAbfQ1BAHYAdmoGLb/NbusxGyladzDA=
 k8s.io/component-base v0.0.0-20191108070619-4b9966ca0181/go.mod h1:OnLnQI0ti1wNBL+pCumQcG9Plt1S6L+lOXsQwQJ+m9g=

--- a/pkg/fwdservice/fwdservice.go
+++ b/pkg/fwdservice/fwdservice.go
@@ -1,0 +1,294 @@
+package fwdservice
+
+import (
+	"fmt"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/pingcap/errors"
+	"github.com/txn2/kubefwd/pkg/fwdnet"
+	"github.com/txn2/kubefwd/pkg/fwdport"
+	"github.com/txn2/kubefwd/pkg/fwdpub"
+
+	log "github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	restclient "k8s.io/client-go/rest"
+)
+
+// Single service which we need to forward, with a reference to all the pods being forwarded for it
+type ServiceFWD struct {
+	ClientSet    *kubernetes.Clientset
+	Context      string
+	Namespace    string
+	ListOptions  metav1.ListOptions
+	Hostfile     *fwdport.HostFileWithLock
+	ClientConfig *restclient.Config
+	RESTClient   *restclient.RESTClient
+	ShortName    bool
+	Remote       bool
+	IpC          byte
+	IpD          *int
+	Domain       string
+
+	PodLabelSelector string                              // The label selector to query for matching pods.
+	NamespaceIPLock  *sync.Mutex                         // Synchronization for IP handout for each portforward
+	Svc              *v1.Service                         // Reference to the k8s service.
+	Headless         bool                                // A headless service will forward all of the pods, while normally only a single pod is forwarded.
+	LastSyncedAt     time.Time                           // When was the set of pods last synced
+	PortForwards     map[string]*fwdport.PortForwardOpts // A mapping of all the pods currently being forwarded. key = podname
+	DoneChannel      chan struct{}                       // After shutdown is complete, this channel will be closed
+}
+
+func (svcFwd *ServiceFWD) String() string {
+	return svcFwd.Svc.Name + "." + svcFwd.Namespace
+}
+
+// GetPodsForService queries k8s and returns all pods backing this service
+func (svcfwd *ServiceFWD) GetPodsForService() []v1.Pod {
+	listOpts := metav1.ListOptions{LabelSelector: svcfwd.PodLabelSelector}
+
+	pods, err := svcfwd.ClientSet.CoreV1().Pods(svcfwd.Svc.Namespace).List(listOpts)
+
+	if err != nil {
+		if errors.IsNotFound(err) {
+			log.Warnf("WARNING: No Pods found for service %s: %s\n", svcfwd, err.Error())
+		} else {
+			log.Warnf("WARNING: Error in List pods for %s: %s\n", svcfwd, err.Error())
+		}
+		return nil
+	}
+
+	return pods.Items
+}
+
+// SyncPodForwards selects one or all pods behind a service, and invokes the forwarding setup for that or those pod(s).
+// It will remove pods in-mem that are no longer returned by k8s, should these not be correctly deleted.
+func (svcfwd *ServiceFWD) SyncPodForwards(force bool) {
+	// When a whole set of pods gets deleted at once, they all will trigger a SyncPodForwards() call. This would hammer k8s with load needlessly.
+	// Therefore keep a timestamp from when this was last called and only allow call if the previous one was not too recent.
+	if !force && time.Since(svcfwd.LastSyncedAt) < 10*time.Minute {
+		log.Debugf("Skipping pods refresh for %s due to rate limiting", svcfwd)
+		return
+	}
+
+	k8sPods := svcfwd.GetPodsForService()
+
+	// If no pods are found currently. Will try again next resync period
+	if len(k8sPods) == 0 {
+		log.Warnf("WARNING: No Running Pods returned for service %s", svcfwd)
+		return
+	}
+
+	// Check if the pods currently being forwarded still exist in k8s and if they are not in a (pre-)running state, if not: remove them
+	for _, podName := range svcfwd.ListPodNames() {
+		keep := false
+		for _, pod := range k8sPods {
+			if podName == pod.Name && (pod.Status.Phase == v1.PodPending || pod.Status.Phase == v1.PodRunning) {
+				keep = true
+				break
+			}
+		}
+		if !keep {
+			svcfwd.RemovePod(podName)
+		}
+	}
+	// Set up portforwarding for one or all of these pods
+	// normal service portforward the first pod as service name. headless service not only forward first Pod as service name, but also portforward all pods.
+	if len(k8sPods) != 0 {
+		if svcfwd.Headless {
+			svcfwd.LoopPodsToForward([]v1.Pod{k8sPods[0]})
+			svcfwd.LoopPodsToForward(k8sPods)
+		} else {
+			// Check if currently we are forwarding a pod which is good to keep using
+			podNameToKeep := ""
+			for _, podName := range svcfwd.ListPodNames() {
+				if podNameToKeep != "" {
+					break
+				}
+				for _, pod := range k8sPods {
+					if podName == pod.Name && (pod.Status.Phase == v1.PodPending || pod.Status.Phase == v1.PodRunning) {
+						podNameToKeep = pod.Name
+						break
+					}
+				}
+			}
+
+			// Stop forwarding others, should there be. In case none of the currently forwarded pods are good to keep,
+			// podNameToKeep will be the empty string, and the comparison will mean we will remove all pods, which is the desired behaviour.
+			for _, podName := range svcfwd.ListPodNames() {
+				if podName != podNameToKeep {
+					svcfwd.RemovePod(podName)
+				}
+			}
+
+			// If no good pod was being forwarded already, start one
+			if podNameToKeep == "" {
+				svcfwd.LoopPodsToForward([]v1.Pod{k8sPods[0]})
+			}
+		}
+	}
+
+	svcfwd.LastSyncedAt = time.Now()
+}
+
+// LoopPodsToForward starts the portforwarding for each pod in the given list
+func (svcfwd *ServiceFWD) LoopPodsToForward(pods []v1.Pod) {
+	publisher := &fwdpub.Publisher{
+		PublisherName: "Services",
+		Output:        false,
+	}
+
+	// If multiple pods need to be forwarded, they all get their own host entry
+	includePodNameInHost := len(pods) > 1
+
+	// Ip address handout is a critical section for synchronization, use a lock which synchronizes inside each namespace.
+	svcfwd.NamespaceIPLock.Lock()
+	defer svcfwd.NamespaceIPLock.Unlock()
+
+	for _, pod := range pods {
+		// If pod is already configured to be forwarded, skip it
+		if _, found := svcfwd.PortForwards[pod.Name]; found {
+			continue
+		}
+
+		podPort := ""
+		svcName := ""
+
+		localIp, dInc, err := fwdnet.ReadyInterface(127, 1, svcfwd.IpC, *svcfwd.IpD, podPort)
+		if err != nil {
+			log.Warnf("WARNING: error readying interface: %s\n", err)
+		}
+		*svcfwd.IpD = dInc
+
+		for _, port := range svcfwd.Svc.Spec.Ports {
+
+			podPort = port.TargetPort.String()
+			localPort := strconv.Itoa(int(port.Port))
+
+			if _, err := strconv.Atoi(podPort); err != nil {
+				// search a pods containers for the named port
+				if namedPodPort, ok := portSearch(podPort, pod.Spec.Containers); ok {
+					podPort = namedPodPort
+				}
+			}
+
+			serviceHostName := svcfwd.Svc.Name
+
+			if includePodNameInHost {
+				serviceHostName = pod.Name + "." + serviceHostName
+			}
+
+			svcName = serviceHostName
+
+			if !svcfwd.ShortName {
+				serviceHostName = serviceHostName + "." + pod.Namespace
+			}
+
+			if svcfwd.Domain != "" {
+				serviceHostName = serviceHostName + "." + svcfwd.Domain
+			}
+
+			if svcfwd.Remote {
+				serviceHostName = fmt.Sprintf("%s.svc.cluster.%s", serviceHostName, svcfwd.Context)
+			}
+
+			log.Debugf("Resolving:    %s to %s\n",
+				serviceHostName,
+				localIp.String(),
+			)
+
+			log.Printf("Port-Forward: %s:%d to pod %s:%s\n",
+				serviceHostName,
+				port.Port,
+				pod.Name,
+				podPort,
+			)
+
+			pfo := &fwdport.PortForwardOpts{
+				Out:        publisher,
+				Config:     svcfwd.ClientConfig,
+				ClientSet:  svcfwd.ClientSet,
+				RESTClient: svcfwd.RESTClient,
+				Context:    svcfwd.Context,
+				Namespace:  pod.Namespace,
+				Service:    svcName,
+				ServiceFwd: svcfwd,
+				PodName:    pod.Name,
+				PodPort:    podPort,
+				LocalIp:    localIp,
+				LocalPort:  localPort,
+				Hostfile:   svcfwd.Hostfile,
+				ShortName:  svcfwd.ShortName,
+				Remote:     svcfwd.Remote,
+				Domain:     svcfwd.Domain,
+
+				ManualStopChan: make(chan struct{}),
+				DoneChan:       make(chan struct{}),
+			}
+
+			// Fire and forget. The stopping is done in the service.Shutdown() method.
+			go func() {
+				svcfwd.AddPod(pfo)
+				if err := pfo.PortForward(); err != nil {
+					select {
+					case <-pfo.ManualStopChan: // if shutdown was given, we don't bother with the error.
+					default:
+						log.Errorf("PortForward error on %s: %s", pfo.PodName, err.Error())
+					}
+				} else {
+					select {
+					case <-pfo.ManualStopChan: // if shutdown was given, don't log a warning as it's an intented stopping.
+					default:
+						log.Warnf("Stopped forwarding pod %s for %s", pfo.PodName, svcfwd)
+					}
+				}
+			}()
+
+		}
+
+	}
+}
+
+func (svcfwd *ServiceFWD) AddPod(pfo *fwdport.PortForwardOpts) {
+	svcfwd.NamespaceIPLock.Lock()
+	if _, found := svcfwd.PortForwards[pfo.PodName]; !found {
+		svcfwd.PortForwards[pfo.PodName] = pfo
+	}
+	svcfwd.NamespaceIPLock.Unlock()
+}
+
+func (svcfwd *ServiceFWD) ListPodNames() []string {
+	svcfwd.NamespaceIPLock.Lock()
+	currentPodNames := make([]string, 0, len(svcfwd.PortForwards))
+	for podName := range svcfwd.PortForwards {
+		currentPodNames = append(currentPodNames, podName)
+	}
+	svcfwd.NamespaceIPLock.Unlock()
+	return currentPodNames
+}
+
+func (svcfwd *ServiceFWD) RemovePod(podName string) {
+	if pod, found := svcfwd.PortForwards[podName]; found {
+		pod.Stop()
+		<-pod.DoneChan
+		svcfwd.NamespaceIPLock.Lock()
+		delete(svcfwd.PortForwards, podName)
+		svcfwd.NamespaceIPLock.Unlock()
+	}
+}
+
+func portSearch(portName string, containers []v1.Container) (string, bool) {
+	for _, container := range containers {
+		for _, cp := range container.Ports {
+			if cp.Name == portName {
+				return fmt.Sprint(cp.ContainerPort), true
+			}
+		}
+	}
+
+	return "", false
+}

--- a/pkg/fwdsvcregistry/fwdsvcregistry.go
+++ b/pkg/fwdsvcregistry/fwdsvcregistry.go
@@ -1,0 +1,139 @@
+package fwdsvcregistry
+
+import (
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/txn2/kubefwd/pkg/fwdservice"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+)
+
+// ServicesRegistry is a structure to hold all of the services we need to do portforwarding for.
+type ServicesRegistry struct {
+	mutex          *sync.Mutex
+	services       map[string]*fwdservice.ServiceFWD
+	shutDownSignal <-chan struct{}
+	doneSignal     chan struct{} // indicates when all services were succesfully shutdown
+}
+
+var svcRegistry *ServicesRegistry
+
+func Init(shutDownSignal <-chan struct{}) {
+	svcRegistry = &ServicesRegistry{
+		mutex:          &sync.Mutex{},
+		services:       make(map[string]*fwdservice.ServiceFWD),
+		shutDownSignal: shutDownSignal,
+		doneSignal:     make(chan struct{}),
+	}
+
+	go func() {
+		<-svcRegistry.shutDownSignal
+		ShutDownAll()
+		close(svcRegistry.doneSignal)
+	}()
+}
+
+func Done() <-chan struct{} {
+	if svcRegistry != nil {
+		return svcRegistry.doneSignal
+	}
+	// No registry initialized, return a dummy channel then and close it ourselves
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}
+
+// Add will add this service to the registry of services configured to do forwarding (if it wasn't already configured) and start the portforwarding process.
+func Add(svcfwd *fwdservice.ServiceFWD) {
+	// If we are already shutting down, don't add a new service anymore.
+	select {
+	case <-svcRegistry.shutDownSignal:
+		return
+	default:
+	}
+
+	svcRegistry.mutex.Lock()
+	defer svcRegistry.mutex.Unlock()
+
+	if _, found := svcRegistry.services[svcfwd.String()]; !found {
+		svcRegistry.services[svcfwd.String()] = svcfwd
+		log.Debugf("Starting forwarding service %s", svcfwd)
+	} else {
+		return
+	}
+
+	// Start the portforwarding
+	go svcfwd.SyncPodForwards(false)
+
+	// Schedule a resync every x minutes to deal with potential connection errors.
+	go func() {
+		for {
+			select {
+			case <-time.After(10 * time.Minute):
+				svcfwd.SyncPodForwards(false)
+			case <-svcfwd.DoneChannel:
+				return
+			}
+		}
+	}()
+}
+
+// SyncAll does a pod sync for all known services.
+func SyncAll() {
+	// If we are already shutting down, don't sync services anymore.
+	select {
+	case <-svcRegistry.shutDownSignal:
+		return
+	default:
+	}
+
+	for _, svc := range svcRegistry.services {
+		svc.SyncPodForwards(true)
+	}
+}
+
+// ShutDownAll will shutdown all active services and remove them from the registry
+func ShutDownAll() {
+	for name := range svcRegistry.services {
+		RemoveByName(name)
+	}
+	log.Debugf("All services have shut down")
+}
+
+// RemoveByName will shutdown and remove the service, identified by svcName.svcNamespace, from the inventory of services, if it was currently being configured to do forwarding.
+func RemoveByName(name string) {
+	// Pop the service from the registry
+	svcRegistry.mutex.Lock()
+	svcfwd, found := svcRegistry.services[name]
+	if !found {
+		svcRegistry.mutex.Unlock()
+		return
+	}
+	delete(svcRegistry.services, name)
+	svcRegistry.mutex.Unlock()
+
+	// Synchronously stop the forwarding of all active pods in it
+	activePodForwards := svcfwd.ListPodNames()
+	log.Debugf("Stopping service %s with %d portforward(s)", svcfwd, len(activePodForwards))
+
+	podsAllDone := &sync.WaitGroup{}
+	podsAllDone.Add(len(activePodForwards))
+	for _, podName := range activePodForwards {
+		go func(podName string) {
+			svcfwd.RemovePod(podName)
+			podsAllDone.Done()
+		}(podName)
+	}
+	podsAllDone.Wait()
+
+	// Signal that the service has shut down
+	close(svcfwd.DoneChannel)
+}
+
+// GetByName returns the ServiceFWD object, if it currently being forwarded.
+func GetByName(name string) *fwdservice.ServiceFWD {
+	svcRegistry.mutex.Lock()
+	defer svcRegistry.mutex.Unlock()
+	return svcRegistry.services[name]
+}


### PR DESCRIPTION
Change the structuring to better deal with pod rotation, connections lost and clean exit behaviour. This makes it not exit when there are temporarily no pods for a service, or when no services exist for a namespace yet (both currently just exit the program instead of waiting).

It periodically refreshes pods for a service to deal with pods that are no longer working (set to 10 minutes, is it worth to make this configurable by the user?).