### PR TITLE
Hostsfile improvement

### DIFF
--- a/cmd/kubefwd/services/services.go
+++ b/cmd/kubefwd/services/services.go
@@ -230,6 +230,8 @@ Try:
 		contexts = append(contexts, rawConfig.CurrentContext)
 	}
 
+	hostFileWLock := &fwdport.HostFileWithLock{Hosts: hostFile}
+
 	for i, ctx := range contexts {
 		// k8s REST config
 		restConfig, err := configGetter.GetRestConfig(cfgFilePath, ctx)
@@ -264,7 +266,7 @@ Try:
 				Context:      ctx,
 				Namespace:    namespace,
 				ListOptions:  listOptions,
-				Hostfile:     &fwdport.HostFileWithLock{Hosts: hostFile},
+				Hostfile:     hostFileWLock,
 				ClientConfig: restConfig,
 				RESTClient:   restClient,
 				ShortName:    i < 1 && ii < 1,

--- a/pkg/fwdport/fwdport.go
+++ b/pkg/fwdport/fwdport.go
@@ -178,6 +178,7 @@ func (pfo *PortForwardOpts) BuildTheHostsParams() {
 // this method to add hosts obj in /etc/hosts
 func (pfo *PortForwardOpts) AddHosts() {
 	pfo.Hostfile.Lock()
+	defer pfo.Hostfile.Unlock()
 
 	localIpAsString := pfo.LocalIp.String()
 
@@ -228,7 +229,6 @@ func (pfo *PortForwardOpts) AddHosts() {
 	if err != nil {
 		log.Error("Error saving hosts file", err)
 	}
-	pfo.Hostfile.Unlock()
 }
 
 // this method to remove hosts obj in /etc/hosts
@@ -236,6 +236,7 @@ func (pfo *PortForwardOpts) removeHosts() {
 	// we should lock the pfo.Hostfile here
 	// because sometimes other goroutine write the *txeh.Hosts
 	pfo.Hostfile.Lock()
+	defer pfo.Hostfile.Unlock()
 	// other applications or process may have written to /etc/hosts
 	// since it was originally updated.
 	err := pfo.Hostfile.Hosts.Reload()
@@ -271,7 +272,6 @@ func (pfo *PortForwardOpts) removeHosts() {
 	if err != nil {
 		log.Errorf("Error saving /etc/hosts: %s\n", err.Error())
 	}
-	pfo.Hostfile.Unlock()
 }
 
 func (pfo *PortForwardOpts) removeInterfaceAlias() {


### PR DESCRIPTION
Some changes related to the hostfile:

1. Previously each serviceOpts got his own hostfile struct with its own mutex, so that's one per namespace. But they should all share the same mutex, as they are all working on the same hostfile. So this has been changed so they all have a pointer to the same hostsfile which avoids race conditions.
2. Unlock() of the hostsfile could be skipped in an error case where a return was done without the unlocking, ricking a deadlock. I've put the Unlock() call in a defer statement to ensure it always unlocks.
3. A DNS entry for a service should have a fully qualified entry for it (so ending with a `.`) as described in [the dns specification](https://github.com/kubernetes/dns/blob/master/docs/specification.md). The reason you want to use this to address a service from an application is that by specifying a fully qualified name, you avoid useless dns lookups, so reduce the load on your k8s dns provider (e.g. kube-dns) and improve performance. See also [this blog post about it](https://pracucci.com/kubernetes-dns-resolution-ndots-options-and-why-it-may-affect-application-performances.html) 

For example in our case, a cluster running on GKE, when we do a query for `myService.myNamespace.svc.cluster.local`, these are the lookups a pod will do:

```
myService.myNamespace.svc.cluster.local.nyNamespace.svc.cluster.local.
myService.myNamespace.svc.cluster.local.svc.cluster.local.
myService.myNamespace.svc.cluster.local.cluster.local.
myService.myNamespace.svc.cluster.local.c.<redacted-cluster-name>.internal.
myService.myNamespace.svc.cluster.local.google.internal.
myService.myNamespace.svc.cluster.local. --> result
```

This is because it loops over the search domains. By specifying the FQDN, so calling `myService.myNamespace.svc.cluster.local.`, you skip the searchDomains and jump immediately to the correct lookup, thus a performance gain + less load on kube-dns. The problem with kubefwd currently is that it does not have that dns entry in the hostsfile. An application which is addressing a service using this FQDN doesn't work. Therefor the change is made here to include the FQDN as well, so that this works.