### PR TITLE
Allow setting logging verbosity

### DIFF
--- a/cmd/kubefwd/kubefwd.go
+++ b/cmd/kubefwd/kubefwd.go
@@ -17,7 +17,6 @@ package main
 
 import (
 	"bytes"
-	"fmt"
 	"os"
 
 	log "github.com/sirupsen/logrus"
@@ -27,15 +26,7 @@ import (
 
 var globalUsage = ``
 var Version = "0.0.0"
-
-func init() {
-	// quiet version
-	args := os.Args[1:]
-	if len(args) == 2 && args[0] == "version" && args[1] == "quiet" {
-		fmt.Println(Version)
-		os.Exit(0)
-	}
-}
+var SourceRepository = "https://github.com/txn2/kubefwd"
 
 func newRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -49,6 +40,7 @@ func newRootCmd() *cobra.Command {
 		Long: globalUsage,
 	}
 
+	var quiet bool
 	versionCmd := &cobra.Command{
 		Use:   "version",
 		Short: "Print the version of Kubefwd",
@@ -56,9 +48,10 @@ func newRootCmd() *cobra.Command {
 			" kubefwd version quiet\n",
 		Long: ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("Kubefwd version: %s\nhttps://github.com/txn2/kubefwd\n", Version)
+			services.PrintProgramHeader(quiet)
 		},
 	}
+	versionCmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "Print short version info instead of full header.")
 
 	cmd.AddCommand(versionCmd, services.Cmd)
 
@@ -75,6 +68,10 @@ func (splitter *LogOutputSplitter) Write(p []byte) (n int, err error) {
 }
 
 func main() {
+	// Pass version info to services package where it is printed
+	services.Version = Version
+	services.SourceRepository = SourceRepository
+
 	log.SetFormatter(&log.TextFormatter{
 		FullTimestamp:   true,
 		ForceColors:     true,
@@ -82,16 +79,6 @@ func main() {
 	})
 
 	log.SetOutput(&LogOutputSplitter{})
-
-	log.Print(` _          _           __             _`)
-	log.Print(`| | ___   _| |__   ___ / _|_      ____| |`)
-	log.Print(`| |/ / | | | '_ \ / _ \ |_\ \ /\ / / _  |`)
-	log.Print(`|   <| |_| | |_) |  __/  _|\ V  V / (_| |`)
-	log.Print(`|_|\_\\__,_|_.__/ \___|_|   \_/\_/ \__,_|`)
-	log.Print("")
-	log.Printf("Version %s", Version)
-	log.Print("https://github.com/txn2/kubefwd")
-	log.Print("")
 
 	cmd := newRootCmd()
 


### PR DESCRIPTION
In order to use this during our CI/CD process, we needed to be able to silence the output as it is running as a background process in a container. With this change the logging level can be set (rather than just 'verbose or not') which allows for more fine-tuned output.

When setting it to error level, most of the output is hidden when running this as a sidecar/background process next to your real program, only errors will show up in the logs, which we want.

I made the version command use cmdline flags, which got rid of the not-so-clean init function and is more in line with the rest of the program using Cobra.

Output examples now:

```
Mathieus-MacBook-Pro:kubefwd mhindery$ sudo go run *.go svc -v 1 -n default -l lalala=yes
Mathieus-MacBook-Pro:kubefwd mhindery$ sudo go run *.go svc -v 5 -n default -l lalala=yes
INFO[23:09:28]  _          _           __             _     
INFO[23:09:28] | | ___   _| |__   ___ / _|_      ____| |    
INFO[23:09:28] | |/ / | | | '_ \ / _ \ |_\ \ /\ / / _  |    
INFO[23:09:28] |   <| |_| | |_) |  __/  _|\ V  V / (_| |    
INFO[23:09:28] |_|\_\\__,_|_.__/ \___|_|   \_/\_/ \__,_|    
INFO[23:09:28]                                              
INFO[23:09:28] Version 0.0.0                                
INFO[23:09:28] Source https://github.com/txn2/kubefwd       
INFO[23:09:28]                                              
INFO[23:09:28] Press [Ctrl-C] to stop forwarding.           
INFO[23:09:28] 'cat /etc/hosts' to see all host entries.    
INFO[23:09:28] Loaded hosts file /etc/hosts                 
INFO[23:09:28] Hostfile management: Original hosts backup already exists at /Users/mhindery/hosts.original 
INFO[23:09:28] Succesfully connected context: <redacted> 
INFO[23:09:32] Done...                                      
Mathieus-MacBook-Pro:kubefwd mhindery$ sudo go run *.go version
INFO[23:09:41]  _          _           __             _     
INFO[23:09:41] | | ___   _| |__   ___ / _|_      ____| |    
INFO[23:09:41] | |/ / | | | '_ \ / _ \ |_\ \ /\ / / _  |    
INFO[23:09:41] |   <| |_| | |_) |  __/  _|\ V  V / (_| |    
INFO[23:09:41] |_|\_\\__,_|_.__/ \___|_|   \_/\_/ \__,_|    
INFO[23:09:41]                                              
INFO[23:09:41] Version 0.0.0                                
INFO[23:09:41] Source https://github.com/txn2/kubefwd       
INFO[23:09:41]                                              
Mathieus-MacBook-Pro:kubefwd mhindery$ sudo go run *.go version -q
Kubefwd version: 0.0.0
https://github.com/txn2/kubefwd
Mathieus-MacBook-Pro:kubefwd mhindery$ 
```