### PR TITLE
Attempt to set the full name of services when more than 1 namespace or context

### DIFF
--- a/pkg/fwdport/fwdport.go
+++ b/pkg/fwdport/fwdport.go
@@ -170,13 +170,12 @@ func (pfo *PortForwardOpts) AddHosts() {
 
 	pfo.Hostfile.Lock()
 	if pfo.Remote {
-
 		pfo.Hostfile.Hosts.RemoveHost(pfo.HostsParams.fullServiceName)
 		pfo.Hostfile.Hosts.RemoveHost(pfo.HostsParams.svcServiceName)
 		if pfo.Domain != "" {
 			pfo.Hostfile.Hosts.AddHost(pfo.LocalIp.String(), pfo.Service+"."+pfo.Domain)
 		}
-		pfo.Hostfile.Hosts.AddHost(pfo.LocalIp.String(), pfo.Service)
+		pfo.Hostfile.Hosts.AddHost(pfo.LocalIp.String(), pfo.HostsParams.fullServiceName)
 
 	} else {
 


### PR DESCRIPTION
Related to #136 

I have _never_ written go in my life so please be gentle :)

I'm also sure there's tons of better ways to structure this (e.g. probably a flag to control the behavior?)

My org has several clusters/namespaces with services that use the same ports, and being able to distinguish them would be super helpful. I was unable to get parallel instances of kubefwd -d to work without creating IP collisions or something I didn't fully grok that caused errors when setting up the forwards.

Also, even with this change in place I'm still finding the bare service name is added to /etc/hosts and I am not entirely sure how!