### PR TITLE
Multi-cluster fixes

### DIFF
--- a/cmd/kubefwd/services/services_test.go
+++ b/cmd/kubefwd/services/services_test.go
@@ -123,7 +123,6 @@ func buildFwdServiceOpts(t *testing.T, namespace string) *FwdServiceOpts {
 		ClientConfig: restConfig,
 		RESTClient:   restClient,
 		ShortName:    true,
-		Remote:       false,
 		IpC:          byte(ipC),
 		IpD:          ipD,
 		ExitOnFail:   exitOnFail,


### PR DESCRIPTION
- Avoid IP address conflicts by running each cluser & namespace with its own IP address
- Include context in the hash key used to store services, so that services with the same name & namespace from different clusters can co-exist
- Use the same naming scheme for services regardless of whether they are the first cluster on the list or not

Another attempt to fix https://github.com/txn2/kubefwd/issues/136
