### PR TITLE
Use debounce for pod scanning

### DIFF
--- a/cmd/kubefwd/services/services.go
+++ b/cmd/kubefwd/services/services.go
@@ -17,10 +17,12 @@ package services
 
 import (
 	"fmt"
+	"github.com/bep/debounce"
 	"os"
 	"os/signal"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/txn2/kubefwd/pkg/fwdcfg"
 	"github.com/txn2/kubefwd/pkg/fwdhost"
@@ -390,6 +392,7 @@ func (opts *NamespaceOpts) AddServiceHandler(obj interface{}) {
 		NamespaceIPLock:  opts.NamespaceIPLock,
 		Svc:              svc,
 		Headless:         svc.Spec.ClusterIP == "None",
+		SyncDebouncer:    debounce.New(5 * time.Second),
 		PortForwards:     make(map[string]*fwdport.PortForwardOpts),
 		DoneChannel:      make(chan struct{}),
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/txn2/kubefwd
 go 1.13
 
 require (
+	github.com/bep/debounce v1.2.0
 	github.com/elazarl/goproxy v0.0.0-20181111060418-2ce16c963a8a // indirect
 	github.com/pingcap/errors v0.11.4
 	github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
+github.com/bep/debounce v1.2.0 h1:wXds8Kq8qRfwAOpAxHrJDbCXgC5aHSzgQb/0gKsHQqo=
+github.com/bep/debounce v1.2.0/go.mod h1:H8yggRPQKLUhUoqrJC1bO2xNya7vanpDl7xR3ISbCJ0=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5/go.mod h1:/iP1qXHoty45bqomnu2LM+VVyAEdWN+vtSHGlQgyxbw=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=


### PR DESCRIPTION
Instead of syncing the pod list for a service at most once every 10 minutes, apply a debounce on
changes so that we don't sync the pods list unless the service has been stable for 5 seconds or it has been more than 5 minutes since the last sync.

This should help avoid cases where pods are restarted and kubefwd doesn't seem to allow connecting to them any more, because it will sync pods more often than before.