### PR TITLE
Enable debug logging of pod listen events & errors

### DIFF
--- a/pkg/fwdport/fwdport.go
+++ b/pkg/fwdport/fwdport.go
@@ -113,7 +113,7 @@ func (pfo *PortForwardOpts) PortForward() error {
 		return err
 	} else if pod == nil {
 		// if err is not nil but pod is nil
-		// mean service deleted but pod is not runnning.
+		// mean service deleted but pod is not running.
 		// No error, just return
 		pfo.Stop()
 		return nil
@@ -123,6 +123,7 @@ func (pfo *PortForwardOpts) PortForward() error {
 	go pfo.ListenUntilPodDeleted(downstreamStopChannel, pod)
 
 	p := pfo.Out.MakeProducer(localNamedEndPoint)
+	p.Output = log.IsLevelEnabled(log.DebugLevel)
 
 	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, http.MethodPost, req.URL())
 

--- a/pkg/fwdpub/fwdpub.go
+++ b/pkg/fwdpub/fwdpub.go
@@ -21,7 +21,7 @@ func (p *Publisher) Write(b []byte) (int, error) {
 	outputString = strings.TrimSuffix(outputString, "\n")
 
 	if p.Output {
-		fmt.Printf("Out: %s, %s, %s", p.PublisherName, p.ProducerName, outputString)
+		fmt.Printf("Out: %s, %s, %s\n", p.PublisherName, p.ProducerName, outputString)
 	}
 	return 0, nil
 }

--- a/pkg/fwdservice/fwdservice.go
+++ b/pkg/fwdservice/fwdservice.go
@@ -158,7 +158,7 @@ func (svcfwd *ServiceFWD) SyncPodForwards(force bool) {
 func (svcfwd *ServiceFWD) LoopPodsToForward(pods []v1.Pod, includePodNameInHost bool) {
 	publisher := &fwdpub.Publisher{
 		PublisherName: "Services",
-		Output:        false,
+		Output:        log.IsLevelEnabled(log.DebugLevel),
 	}
 
 	// Ip address handout is a critical section for synchronization, use a lock which synchronizes inside each namespace.


### PR DESCRIPTION
This sets the "Output" flag on the publishers for the pod forwarders if you run in verbose mode.  This can reveal some errors / events that are useful for debugging.