### PR TITLE
Upgrade Alpine Linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3
 
 RUN apk add --no-cache curl
 COPY kubefwd /


### PR DESCRIPTION
The dockerfile is using Alpine 3.8, the EOL of that version was in 2020-05-01.

Current Alpine version is 3.12