### PR TITLE
Use debounce for pod scanning

### DIFF
--- a/cmd/kubefwd/services/services.go
+++ b/cmd/kubefwd/services/services.go
@@ -21,7 +21,9 @@ import (
 	"os/signal"
 	"sync"
 	"syscall"
+	"time"
 
+	"github.com/bep/debounce"
 	"github.com/txn2/kubefwd/pkg/fwdcfg"
 	"github.com/txn2/kubefwd/pkg/fwdhost"
 	"github.com/txn2/kubefwd/pkg/fwdport"
@@ -408,6 +410,7 @@ func (opts *NamespaceOpts) AddServiceHandler(obj interface{}) {
 		Svc:                  svc,
 		Headless:             svc.Spec.ClusterIP == "None",
 		PortForwards:         make(map[string]*fwdport.PortForwardOpts),
+		SyncDebouncer:        debounce.New(5 * time.Second),
 		DoneChannel:          make(chan struct{}),
 	}
 


### PR DESCRIPTION
Instead of syncing the pod list for a service at most once every 10 minutes, apply a debounce on
changes so that we don't sync the pods list unless the service has been stable for 5 seconds or it has been more than 5 minutes since the last sync.

This should help avoid cases where pods are restarted and kubefwd doesn't seem to allow connecting to them any more, because it will sync pods more often than before.

*Note* I had previously made a PR for this exact change, which was merged, but most of the changes were lost in a later merge, maybe due to merge conflicts or somesuch.
