### PR TITLE
Spdy stream creation to prevent connection close #170

### DIFF
--- a/pkg/fwdport/fwdport.go
+++ b/pkg/fwdport/fwdport.go
@@ -97,7 +97,7 @@ func (p pingingDialer) stopPing() {
 }
 
 func (p pingingDialer) Dial(protocols ...string) (httpstream.Connection, string, error) {
-	streamConn, streamProtocolVersion, dialErr := p.wrappedDialer.Dial()
+	streamConn, streamProtocolVersion, dialErr := p.wrappedDialer.Dial(protocols...)
 	if dialErr != nil {
 		log.Warnf("Ping process will not be performed for %s, cannot dial", p.pingTargetPodName)
 	}
@@ -108,7 +108,7 @@ func (p pingingDialer) Dial(protocols ...string) (httpstream.Connection, string,
 		for {
 			select {
 			case <-time.After(p.pingPeriod):
-				if pingStream, err := streamConn.CreateStream(nil); err == nil {
+				if pingStream, err := streamConnection.CreateStream(nil); err == nil {
 					_ = pingStream.Reset()
 				}
 			case <-p.pingStopChan:


### PR DESCRIPTION
This approach wraps SPDY dialer that will be used by `PortForwarder`. When `Dial()` calls, another goroutine start to creating new SPDY stream over and over.

Info about streams [here](https://www.chromium.org/spdy/spdy-protocol/spdy-protocol-draft2#TOC-Streams)

However, this approach must be changed when kubernetes port-forward will discard SPDY usage [more info here](https://github.com/kubernetes/kubernetes/issues/7452)