### PR TITLE
feat: add port mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Examples:
   kubefwd svc -n default -n the-project
   kubefwd svc -n default -d internal.example.com
   kubefwd svc -n the-project -x prod-cluster
+  kubefwd svc -n the-project -m 80:8080 -m 443:1443
 
 
 Flags:
@@ -141,6 +142,7 @@ Flags:
   -c, --kubeconfig string   absolute path to a kubectl config file
   -n, --namespace strings   Specify a namespace. Specify multiple namespaces by duplicating this argument.
   -l, --selector string     Selector (label query) to filter on; supports '=', '==', '!=' (e.g. -l key1=value1,key2=value2) and 'in' (e.g. -l "app in (value1, value2)").
+  -m, --mapping strings     Specify a port mapping. Specify multiple mapping by duplicating this argument.
   -v, --verbose             Verbose output.
 ```
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -128,7 +128,8 @@ Examples:
   kubefwd svc -n default -n the-project
   kubefwd svc -n default -d internal.example.com
   kubefwd svc -n the-project -x prod-cluster
-
+  kubefwd svc -n the-project -m 80:8080 -m 443:1443
+  
 
 Flags:
   -x, --context strings     specify a context to override the current context
@@ -138,6 +139,7 @@ Flags:
   -c, --kubeconfig string   absolute path to a kubectl config fil (default "/Users/cjimti/.kube/config")
   -n, --namespace strings   Specify a namespace. Specify multiple namespaces by duplicating this argument.
   -l, --selector string     Selector (label query) to filter on; supports '=', '==', and '!=' (e.g. -l key1=value1,key2=value2).
+  -m, --mapping strings     Specify a port mapping. Specify multiple mapping by duplicating this argument.
   -v, --verbose             Verbose output.
 ```
 

--- a/cmd/kubefwd/kubefwd.go
+++ b/cmd/kubefwd/kubefwd.go
@@ -45,7 +45,9 @@ func newRootCmd() *cobra.Command {
 			"  kubefwd svc -n the-project\n" +
 			"  kubefwd svc -n the-project -l env=dev,component=api\n" +
 			"  kubefwd svc -n default -l \"app in (ws, api)\"\n" +
-			"  kubefwd svc -n default -n the-project\n",
+			"  kubefwd svc -n default -n the-project\n" +
+			"  kubefwd svc -n the-project -m 80:8080 -m 443:1443\n",
+
 		Long: globalUsage,
 	}
 

--- a/pkg/fwdservice/fwdservice.go
+++ b/pkg/fwdservice/fwdservice.go
@@ -59,7 +59,8 @@ type ServiceFWD struct {
 	// while normally only a single pod is forwarded.
 	Headless bool
 
-	LastSyncedAt time.Time // When was the set of pods last synced
+	LastSyncedAt time.Time  // When was the set of pods last synced
+	PortMap      *[]PortMap // port map array.
 
 	// Use debouncer for listing pods so we don't hammer the k8s when a bunch of changes happen at once
 	SyncDebouncer func(f func())
@@ -68,6 +69,15 @@ type ServiceFWD struct {
 	// key = podName
 	PortForwards map[string]*fwdport.PortForwardOpts
 	DoneChannel  chan struct{} // After shutdown is complete, this channel will be closed
+}
+
+/**
+add port map
+@url https://github.com/txn2/kubefwd/issues/121
+*/
+type PortMap struct {
+	SourcePort string
+	TargetPort string
 }
 
 // String representation of a ServiceFWD returns a unique name
@@ -252,8 +262,12 @@ func (svcFwd *ServiceFWD) LoopPodsToForward(pods []v1.Pod, includePodNameInHost 
 			}
 
 			podPort = port.TargetPort.String()
-			localPort := strconv.Itoa(int(port.Port))
-
+			localPort := svcFwd.getPortMap(port.Port)
+			p, err := strconv.ParseInt(localPort, 10, 32)
+			if err != nil {
+				log.Fatal(err)
+			}
+			port.Port = int32(p)
 			if _, err := strconv.Atoi(podPort); err != nil {
 				// search a pods containers for the named port
 				if namedPodPort, ok := portSearch(podPort, pod.Spec.Containers); ok {
@@ -361,4 +375,18 @@ func portSearch(portName string, containers []v1.Container) (string, bool) {
 	}
 
 	return "", false
+}
+
+// port exist port map return
+func (svcFwd *ServiceFWD) getPortMap(port int32) string {
+	p := strconv.Itoa(int(port))
+	if svcFwd.PortMap != nil {
+		for _, portMapInfo := range *svcFwd.PortMap {
+			if p == portMapInfo.SourcePort {
+				//use map port
+				return portMapInfo.TargetPort
+			}
+		}
+	}
+	return p
 }


### PR DESCRIPTION
@cjimti I accept your advice, use -m., and follow the CLI specification. Now we can use -m pod port to host port.
example:
kubefwd svc -m 80:8080 -m 443:1443

It work in host port 8080 , 1443.

