### PR TITLE
Feature/single service selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ Forward all svc for the namespace `the-project` where labeled `system: wx`:
 sudo kubefwd svc -l system=wx -n the-project
 ```
 
+Forward a single service named `my-service` in the namespace `the-project`:
+
+```
+sudo kubefwd svc -n the-project -f metadata.name=my-service
+```
+
 Forward more than one service using the `in` clause:
 ```bash
 sudo kubefwd svc -l "app in (app1, app2)"
@@ -128,6 +134,7 @@ Aliases:
 Examples:
   kubefwd svc -n the-project
   kubefwd svc -n the-project -l app=wx,component=api
+  kubefwd svc -n the-project -f metadata.name=service-name
   kubefwd svc -n default -n the-project
   kubefwd svc -n default -d internal.example.com
   kubefwd svc -n the-project -x prod-cluster

--- a/cmd/kubefwd/kubefwd.go
+++ b/cmd/kubefwd/kubefwd.go
@@ -44,6 +44,7 @@ func newRootCmd() *cobra.Command {
 		Example: " kubefwd services --help\n" +
 			"  kubefwd svc -n the-project\n" +
 			"  kubefwd svc -n the-project -l env=dev,component=api\n" +
+			"  kubefwd svc -n the-project -f metadata.name=service-name\n" +
 			"  kubefwd svc -n default -l \"app in (ws, api)\"\n" +
 			"  kubefwd svc -n default -n the-project\n" +
 			"  kubefwd svc -n the-project -m 80:8080 -m 443:1443\n",


### PR DESCRIPTION
This PR adds service selection by name or others specific metadata using [k8s field selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/).

It differs from the original idea of using regex because it leverages the already available filters from the API and it can query also by **status** (Running, Pending, etc). Nonetheless, it could be a little more verbose compared with the former option.