### PR TITLE
Some bugfixes

### DIFF
--- a/pkg/fwdport/fwdport.go
+++ b/pkg/fwdport/fwdport.go
@@ -230,11 +230,11 @@ func PortForward(pfo *PortForwardOpts) error {
 	// Blocking call
 	if err = pfo.PortForwardHelper.ForwardPorts(fw); err != nil {
 		log.Errorf("ForwardPorts error for %s: %s", pfo, err.Error())
-		pfo.shutdown()
+		pfo.stopAndShutdown()
 
 		return err
 	} else {
-		pfo.shutdown()
+		pfo.stopAndShutdown()
 	}
 
 	return nil

--- a/pkg/fwdport/fwdport_test.go
+++ b/pkg/fwdport/fwdport_test.go
@@ -55,7 +55,7 @@ func TestPortForward_RemovesItselfFromServiceFwd_AfterPortForwardErr(t *testing.
 
 	pfHelper.EXPECT().ForwardPorts(gomock.Any()).Return(pfErr)
 
-	svcFwd.EXPECT().RemoveServicePodByPort(gomock.Eq(pfo.String()), gomock.Eq(pfo.PodPort), gomock.Eq(true))
+	svcFwd.EXPECT().RemoveServicePodByPort(gomock.Eq(pfo.String()), gomock.Eq(pfo.PodPort), gomock.Eq(false))
 	hostsOperator.EXPECT().RemoveHosts().Times(1)
 	hostsOperator.EXPECT().RemoveInterfaceAlias().Times(1)
 
@@ -103,7 +103,7 @@ func TestPortForward_OnlyClosesDownstreamChannels_WhenErrorOnWaitUntilPodRunning
 	pfHelper.EXPECT().GetPortForwardRequest(gomock.Any()).Return(nil)
 	hostsOperator.EXPECT().AddHosts().Times(1)
 	waiter.EXPECT().WaitUntilPodRunning(gomock.Any()).Return(nil, untilPodRunningErr)
-	svcFwd.EXPECT().RemoveServicePodByPort(gomock.Eq(pfo.String()), gomock.Eq(pfo.PodPort), gomock.Eq(true))
+	svcFwd.EXPECT().RemoveServicePodByPort(gomock.Eq(pfo.String()), gomock.Eq(pfo.PodPort), gomock.Eq(false))
 	hostsOperator.EXPECT().RemoveHosts().Times(1)
 	hostsOperator.EXPECT().RemoveInterfaceAlias().Times(1)
 

--- a/pkg/fwdport/fwdport_test.go
+++ b/pkg/fwdport/fwdport_test.go
@@ -66,6 +66,7 @@ func TestPortForward_RemovesItselfFromServiceFwd_AfterPortForwardErr(t *testing.
 	<-pfo.DoneChan
 	assertChannelsClosed(t,
 		assertableChannel{ch:   pfo.DoneChan, name: "DoneChan"},
+		assertableChannel{ch: pfo.ManualStopChan, name: "ManualStopChan"},
 	)
 }
 


### PR DESCRIPTION
This P/R fixes following bugs:
1) Self waiting on stop in case of err in PortForward()
2) Empty hosts field on pods under the same ServiceFwd
3) Unlock misuse if error occured in RemoveHosts()