### PR TITLE
Added address specification for port forwarding

### DIFF
--- a/cmd/kubefwd/kubefwd.go
+++ b/cmd/kubefwd/kubefwd.go
@@ -48,7 +48,8 @@ func newRootCmd() *cobra.Command {
 			"  kubefwd svc -n default -l \"app in (ws, api)\"\n" +
 			"  kubefwd svc -n default -n the-project\n" +
 			"  kubefwd svc -n the-project -m 80:8080 -m 443:1443\n" +
-			"  kubefwd svc --all-namespaces",
+			"  kubefwd svc --all-namespaces" +
+			"  kubefwd svc --all-namespaces -a 0.0.0.0",
 
 		Long: globalUsage,
 	}

--- a/pkg/fwdport/fwdport.go
+++ b/pkg/fwdport/fwdport.go
@@ -85,6 +85,7 @@ type PortForwardOpts struct {
 	Hosts          []string
 	ManualStopChan chan struct{} // Send a signal on this to stop the portforwarding
 	DoneChan       chan struct{} // Listen on this channel for when the shutdown is completed.
+	Addresses      []string
 }
 
 type pingingDialer struct {
@@ -195,10 +196,14 @@ func (pfo *PortForwardOpts) PortForward() error {
 	}
 
 	var address []string
-	if pfo.LocalIp != nil {
-		address = []string{pfo.LocalIp.To4().String(), pfo.LocalIp.To16().String()}
+	if len(pfo.Addresses) < 1 {
+		if pfo.LocalIp != nil {
+			address = []string{pfo.LocalIp.To4().String(), pfo.LocalIp.To16().String()}
+		} else {
+			address = []string{"localhost"}
+		}
 	} else {
-		address = []string{"localhost"}
+		address = pfo.Addresses
 	}
 
 	fw, err := portforward.NewOnAddresses(dialerWithPing, address, fwdPorts, pfStopChannel, make(chan struct{}), &p, &p)

--- a/pkg/fwdservice/fwdservice.go
+++ b/pkg/fwdservice/fwdservice.go
@@ -1,11 +1,11 @@
 package fwdservice
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"sync"
 	"time"
-	"context"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/txn2/kubefwd/pkg/fwdnet"
@@ -70,6 +70,8 @@ type ServiceFWD struct {
 	// key = podName
 	PortForwards map[string]*fwdport.PortForwardOpts
 	DoneChannel  chan struct{} // After shutdown is complete, this channel will be closed
+
+	Addresses []string
 }
 
 /**
@@ -310,6 +312,7 @@ func (svcFwd *ServiceFWD) LoopPodsToForward(pods []v1.Pod, includePodNameInHost 
 
 				ManualStopChan: make(chan struct{}),
 				DoneChan:       make(chan struct{}),
+				Addresses:      svcFwd.Addresses,
 			}
 
 			// Fire and forget. The stopping is done in the service.Shutdown() method.


### PR DESCRIPTION
The current implementation allows making forwarding only to localhost. At the same time kubectl has -address parameters allowing to open forwarding to LAN. 
I needed this option for my current project and decided that it might be interesting to someone else