### PR TITLE
delete minor unreachable code caused by log.Fatal

### DIFF
--- a/cmd/kubefwd/services/services.go
+++ b/cmd/kubefwd/services/services.go
@@ -182,7 +182,6 @@ Try:
 	hostFile, err := txeh.NewHostsDefault()
 	if err != nil {
 		log.Fatalf("HostFile error: %s", err.Error())
-		os.Exit(1)
 	}
 
 	log.Printf("Loaded hosts file %s\n", hostFile.ReadFilePath)
@@ -190,7 +189,6 @@ Try:
 	msg, err := fwdhost.BackupHostFile(hostFile)
 	if err != nil {
 		log.Fatalf("Error backing up hostfile: %s\n", err.Error())
-		os.Exit(1)
 	}
 
 	log.Printf("HostFile management: %s", msg)
@@ -218,7 +216,6 @@ Try:
 	rawConfig, err := configGetter.GetClientConfig(cfgFilePath)
 	if err != nil {
 		log.Fatalf("Error in get rawConfig: %s\n", err.Error())
-		os.Exit(1)
 	}
 
 	// labels selector to filter services
@@ -303,7 +300,6 @@ Try:
 		restClient, err := configGetter.GetRESTClient()
 		if err != nil {
 			log.Fatalf("Error creating k8s RestClient: %s\n", err.Error())
-			os.Exit(1)
 		}
 
 		for ii, namespace := range namespaces {


### PR DESCRIPTION
Signed-off-by: Abirdcfly <fp544037857@gmail.com>

https://github.com/txn2/kubefwd/blob/df9078d2e60893a360469c2c79b3102c65918809/cmd/kubefwd/services/services.go#L38

https://pkg.go.dev/github.com/sirupsen/logrus#Fatalf
> Fatalf logs a message at level Fatal on the standard logger then the process will exit with status set to 1.

