### PR TITLE
Suppress log output for __complete commands

### DIFF
--- a/cmd/kubefwd/kubefwd.go
+++ b/cmd/kubefwd/kubefwd.go
@@ -38,7 +38,7 @@ func init() {
 	}
 
 	log.SetOutput(&LogOutputSplitter{})
-	if len(args) > 0 && args[0] == "completion" {
+	if len(args) > 0 && (args[0] == "completion" || args[0] == "__complete") {
 		log.SetOutput(ioutil.Discard)
 	}
 }


### PR DESCRIPTION
Similar to `completion`, we should discard log output for `__complete` sub-commands that are used internally by generated shell completion scripts. Otherwise, kubefwd's banner/header that is logged is interpreted as completion targets.

Affected shells:
- bash (tested: `GNU bash, version 5.2.15(1)-release (x86_64-pc-linux-gnu)`)
- zsh (tested: `zsh 5.9 (x86_64-pc-linux-gnu)`)
- fish (tested: `fish, version 3.6.0`)

Steps to reproduce directly:
- Execute command: `kubefwd __complete ""`

Actual output:
```
INFO[14:23:23]  _          _           __             _
INFO[14:23:23] | | ___   _| |__   ___ / _|_      ____| |
INFO[14:23:23] | |/ / | | | '_ \ / _ \ |_\ \ /\ / / _  |
INFO[14:23:23] |   <| |_| | |_) |  __/  _|\ V  V / (_| |
INFO[14:23:23] |_|\_\\__,_|_.__/ \___|_|   \_/\_/ \__,_|
INFO[14:23:23]
INFO[14:23:23] Version 1.22.4
INFO[14:23:23] https://github.com/txn2/kubefwd
INFO[14:23:23]
completion	Generate the autocompletion script for the specified shell
help	Help about any command
services	Forward services
version	Print the version of Kubefwd
:4
Completion ended with directive: ShellCompDirectiveNoFileComp
```

Expected output:
```
completion	Generate the autocompletion script for the specified shell
help	Help about any command
services	Forward services
version	Print the version of Kubefwd
:4
Completion ended with directive: ShellCompDirectiveNoFileComp
```

Fixes txn2/kubefwd#259
Relates txn2/kubefwd#230