### PR TITLE
fix: Listen for pod deletion and properly reconnect

### DIFF
--- a/pkg/fwdport/fwdport.go
+++ b/pkg/fwdport/fwdport.go
@@ -184,7 +184,7 @@ func (pfo *PortForwardOpts) PortForward() error {
 
 	// Listen for pod is deleted
 	// @TODO need a test for this, does not seem to work as intended
-	// go pfo.ListenUntilPodDeleted(downstreamStopChannel, pod)
+	go pfo.ListenUntilPodDeleted(downstreamStopChannel, pod)
 
 	p := pfo.Out.MakeProducer(localNamedEndPoint)
 
@@ -455,10 +455,20 @@ func (pfo *PortForwardOpts) ListenUntilPodDeleted(stopChannel <-chan struct{}, p
 			break
 		}
 		switch event.Type {
+		case watch.Modified:
+			log.Warnf("Pod %s modified, service %s pod new status %v", pod.ObjectMeta.Name, pfo.ServiceFwd, pod)
+			if (event.Object.(*v1.Pod)).DeletionTimestamp != nil {
+				log.Warnf("Pod %s marked for deletion, resyncing the %s service pods.", pod.ObjectMeta.Name, pfo.ServiceFwd)
+				pfo.Stop()
+				pfo.ServiceFwd.SyncPodForwards(false)
+			}
+			//return
 		case watch.Deleted:
 			log.Warnf("Pod %s deleted, resyncing the %s service pods.", pod.ObjectMeta.Name, pfo.ServiceFwd)
+			// TODO - Disconnect / reconnect on the provided port
+			log.Warnf("Pod %s deleted, resyncing the %s service pods.", pod.ObjectMeta.Name, pfo.ServiceFwd)
+			pfo.Stop()
 			pfo.ServiceFwd.SyncPodForwards(false)
-			return
 		}
 	}
 }

--- a/pkg/fwdsvcregistry/fwdsvcregistry.go
+++ b/pkg/fwdsvcregistry/fwdsvcregistry.go
@@ -1,11 +1,10 @@
 package fwdsvcregistry
 
 import (
-	"sync"
-
 	log "github.com/sirupsen/logrus"
 	"github.com/txn2/kubefwd/pkg/fwdservice"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"sync"
 )
 
 // ServicesRegistry is a structure to hold all of the kubernetes
@@ -77,7 +76,7 @@ func Add(serviceFwd *fwdservice.ServiceFWD) {
 	//go func() {
 	//	for {
 	//		select {
-	//		case <-time.After(10 * time.Minute):
+	//		case <-time.After(10 * time.Second):
 	//			serviceFwd.SyncPodForwards(false)
 	//		case <-serviceFwd.DoneChannel:
 	//			return

--- a/pkg/fwdsvcregistry/fwdsvcregistry.go
+++ b/pkg/fwdsvcregistry/fwdsvcregistry.go
@@ -1,10 +1,11 @@
 package fwdsvcregistry
 
 import (
+	"sync"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/txn2/kubefwd/pkg/fwdservice"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
-	"sync"
 )
 
 // ServicesRegistry is a structure to hold all of the kubernetes
@@ -76,7 +77,7 @@ func Add(serviceFwd *fwdservice.ServiceFWD) {
 	//go func() {
 	//	for {
 	//		select {
-	//		case <-time.After(10 * time.Second):
+	//		case <-time.After(10 * time.Minute):
 	//			serviceFwd.SyncPodForwards(false)
 	//		case <-serviceFwd.DoneChannel:
 	//			return


### PR DESCRIPTION
Sometimes, `k8s` doesn't send the `watch.Deleted` event soon enough. However, if we watch the `watch.Modified` for the `.DeletionTimestamp` to be set (`!= nil`), we can trigger a reconnect, which will cause the connection to attach to the upcoming pods. Then, the existing pod can be deleted safely, and the connection will remain live. In-flight traffic during the connect-to-new-pod action will be lost, but any subsequent traffic will be successfully routed to the new pods.