### PR TITLE
Drop use of deprecated ioutils package

### DIFF
--- a/cmd/kubefwd/kubefwd.go
+++ b/cmd/kubefwd/kubefwd.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,7 +18,7 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	log "github.com/sirupsen/logrus"
@@ -39,7 +39,7 @@ func init() {
 
 	log.SetOutput(&LogOutputSplitter{})
 	if len(args) > 0 && (args[0] == "completion" || args[0] == "__complete") {
-		log.SetOutput(ioutil.Discard)
+		log.SetOutput(io.Discard)
 	}
 }
 


### PR DESCRIPTION
ioutils was deprecated in go 1.16. I have not seen plans for its full removal, but that could happen at any point since all pre-deprecated versions of Go are now end of life.

This is a trivial update to switch from using the deprecated module to the current recommended replacement since the minimum kubefwd go version is set to 1.18.