### PR TITLE
chore: stop concurrency race when removing entries from hostfile on graceful shutdown

### DIFF
--- a/cmd/kubefwd/services/services.go
+++ b/cmd/kubefwd/services/services.go
@@ -270,6 +270,8 @@ Try:
 
 	nsWatchesDone := &sync.WaitGroup{} // We'll wait on this to exit the program. Done() indicates that all namespace watches have shutdown cleanly.
 
+	hostFileWithLock := &fwdport.HostFileWithLock{Hosts: hostFile}
+
 	for i, ctx := range contexts {
 		// k8s REST config
 		restConfig, err := configGetter.GetRestConfig(cfgFilePath, ctx)
@@ -316,7 +318,7 @@ Try:
 				// each cluster and namespace has its own ip range
 				NamespaceIPLock:   &sync.Mutex{},
 				ListOptions:       listOptions,
-				HostFile:          &fwdport.HostFileWithLock{Hosts: hostFile},
+				HostFile:          hostFileWithLock,
 				ClientConfig:      *restConfig,
 				RESTClient:        *restClient,
 				ClusterN:          i,


### PR DESCRIPTION
This is a potential solution for a fix that solves the concurrency race when gracefully shutting down the kubefwd process.
Moved the `HostFileWithLock` initialization outside of the loop that creates the namespace watchers, which ensures that all services use the same mutex, ensuring that everyone "takes turns" editing the host file, avoiding the race condition before the process is completely shutdown.
Added some retry logic specific to windows resilience, which attempts to retry to write to the hostfile 10 times if the file is locked. This solves the issue of failing right away when the file is locked (_works hand in hand with the mutual mutex solution_).

