### PR TITLE
Fix PodRemoved events missing LocalPort field

### DIFF
--- a/pkg/fwdservice/fwdservice.go
+++ b/pkg/fwdservice/fwdservice.go
@@ -228,14 +228,16 @@ func (svcFwd *ServiceFWD) StopAllPortForwards() {
 	for _, pfo := range forwards {
 		pfo.Stop()
 		if fwdtui.IsEnabled() {
-			fwdtui.Emit(events.NewPodEvent(
+			event := events.NewPodEvent(
 				events.PodRemoved,
 				pfo.Service,
 				pfo.Namespace,
 				pfo.Context,
 				pfo.PodName,
 				svcFwd.String(),
-			))
+			)
+			event.LocalPort = pfo.LocalPort
+			fwdtui.Emit(event)
 		}
 	}
 }
@@ -547,14 +549,16 @@ func (svcFwd *ServiceFWD) LoopPodsToForward(pods []v1.Pod, includePodNameInHost 
 
 				// Emit PodRemoved event so TUI can clean up the entry
 				if fwdtui.IsEnabled() {
-					fwdtui.Emit(events.NewPodEvent(
+					event := events.NewPodEvent(
 						events.PodRemoved,
 						pfo.Service,
 						pfo.Namespace,
 						pfo.Context,
 						pfo.PodName,
 						svcFwd.String(),
-					))
+					)
+					event.LocalPort = pfo.LocalPort
+					fwdtui.Emit(event)
 				}
 
 				// If there was an error, we should try to reconnect
@@ -653,14 +657,16 @@ func (svcFwd *ServiceFWD) RemoveServicePod(servicePodName string) {
 		// Use pod (PortForwardOpts) values to match metrics key construction exactly
 		// Pass svcFwd.String() as registryKey for proper registry lookup
 		if fwdtui.IsEnabled() {
-			fwdtui.Emit(events.NewPodEvent(
+			event := events.NewPodEvent(
 				events.PodRemoved,
 				pod.Service,
 				pod.Namespace,
 				pod.Context,
 				pod.PodName,
 				svcFwd.String(), // registryKey for reconnection lookup
-			))
+			)
+			event.LocalPort = pod.LocalPort
+			fwdtui.Emit(event)
 		}
 	}
 }

--- a/pkg/fwdservice/fwdservice_test.go
+++ b/pkg/fwdservice/fwdservice_test.go
@@ -1630,10 +1630,14 @@ func TestStopAllPortForwards_EmitsPodRemoved(t *testing.T) {
 		t.Errorf("Expected %d PodRemoved events for 'test-svc', got %d", numForwards, len(podRemovedEvents))
 	}
 
-	// Verify each event has correct service info
+	// Verify each event has correct service info including LocalPort
 	for _, event := range podRemovedEvents {
 		if event.Namespace != "default" {
 			t.Errorf("Expected Namespace 'default', got '%s'", event.Namespace)
+		}
+		// Critical: LocalPort must be set for TUI to match the removal key
+		if event.LocalPort != "80" {
+			t.Errorf("Expected LocalPort '80', got '%s'", event.LocalPort)
 		}
 	}
 }


### PR DESCRIPTION
## Description

The TUI state store uses a key of `ServiceKey.PodName.LocalPort` for both adding and removing entries. However, PodRemoved events were not setting the LocalPort field, causing the removal key to be different from the add key (e.g., "svc.ns.ctx.pod." instead of "svc.ns.ctx.pod.80").

This caused duplicate entries to accumulate in the TUI because old entries were never being removed.

Fixed by setting `event.LocalPort = pfo.LocalPort` on all PodRemoved events. Added test assertion to verify LocalPort is set.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test improvement (new or updated tests)
- [ ] Documentation update
- [ ] Stability/performance improvement
- [ ] Build/CI improvement

> **Note:** New features are developed by maintainers only. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.

## Related Issues

Fixes duplicate TUI entries when pods are killed/recreated with auto-reconnect enabled.

## Testing

- [x] Ran `go test ./...` locally
- [x] Tested manually with a Kubernetes cluster
- [x] Added new tests for changes (if applicable)

**Manual test:**
1. Run `sudo -E ./kubefwd svc -n kft1,kft2 -a --tui`
2. Kill a pod: `kubectl delete pod <pod-name> -n kft1`
3. Observe old entry is removed and new entry appears (no duplicates)

## Checklist

- [x] My code follows the project's style guidelines (`go fmt`, `go vet`)
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have updated documentation if needed
- [x] This PR is focused and does not include unrelated changes

## Screenshots/Logs (if applicable)

**Before fix:** Old entries accumulated because removal key didn't match:
```
api-gateway    80    kft1    Active    0 B
api-gateway    80    kft1    Active    1.2 KB  (duplicate!)
```

**After fix:** Old entry removed, only new entry remains.
