### PR TITLE
Filter PodRemoved events by valid pod names to improve test isolation

### DIFF
--- a/pkg/fwdservice/fwdservice_test.go
+++ b/pkg/fwdservice/fwdservice_test.go
@@ -1617,11 +1617,13 @@ func TestStopAllPortForwards_EmitsPodRemoved(t *testing.T) {
 		t.Fatalf("Expected %d PodRemoved events, got %d", numForwards, collector.CountOfType(events.PodRemoved))
 	}
 
-	// Filter events for this specific service (extra safety against parallel test pollution)
+	// Filter events for this specific test's pods (extra safety against parallel test pollution)
+	// This test uses pod-a, pod-b, pod-c
+	validPods := map[string]bool{"pod-a": true, "pod-b": true, "pod-c": true}
 	allPodRemovedEvents := collector.EventsOfType(events.PodRemoved)
 	var podRemovedEvents []events.Event
 	for _, e := range allPodRemovedEvents {
-		if e.Service == "test-svc" {
+		if e.Service == "test-svc" && validPods[e.PodName] {
 			podRemovedEvents = append(podRemovedEvents, e)
 		}
 	}


### PR DESCRIPTION
## Description

Fix flaky `TestStopAllPortForwards_EmitsPodRemoved` test that was failing intermittently in CI (especially on macOS).

The test filters events by service name "test-svc", but other parallel tests also use this service name, causing event pollution. Added filtering by specific pod names (pod-a, pod-b, pod-c) to ensure only events from this test are counted.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Test improvement (new or updated tests)
- [ ] Documentation update
- [ ] Stability/performance improvement
- [ ] Build/CI improvement

> **Note:** New features are developed by maintainers only. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.

## Related Issues

Fixes CI failures in PR #309 and previous PRs where macOS tests failed with "Expected 3 PodRemoved events, got 4".

## Testing

- [x] Ran `go test ./...` locally
- [ ] Tested manually with a Kubernetes cluster
- [x] Added new tests for changes (if applicable)

## Checklist

- [x] My code follows the project's style guidelines (`go fmt`, `go vet`)
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have updated documentation if needed
- [x] This PR is focused and does not include unrelated changes

## Screenshots/Logs (if applicable)

**Before fix (CI failure):**
```
--- FAIL: TestStopAllPortForwards_EmitsPodRemoved (0.01s)
    fwdservice_test.go:1630: Expected 3 PodRemoved events for 'test-svc', got 4
```

**After fix:** Test passes consistently by filtering on both service name AND pod names.
