### PR TITLE
fix: add Cosign signature bundle to releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -58,11 +58,11 @@ checksum:
 signs:
   - cmd: cosign
     artifacts: checksum
+    signature: "${artifact}.sigstore.json"
     args:
       - "sign-blob"
       - "--yes"
-      - "--output-signature=${signature}"
-      - "--output-certificate=${certificate}"
+      - "--bundle=${signature}"
       - "${artifact}"
 
 # Generate Software Bill of Materials for archives

--- a/README.md
+++ b/README.md
@@ -140,6 +140,33 @@ docker run -it --rm --privileged \
 
 See [Advanced Usage](docs/advanced-usage.md#docker-integration) for Docker Compose examples and [Getting Started](docs/getting-started.md) for complete installation instructions.
 
+## Verifying Downloads
+
+All release artifacts are signed using [Cosign](https://github.com/sigstore/cosign) keyless signing with GitHub Actions OIDC.
+
+### Verify Checksums
+
+```bash
+# Download the checksum file and signature bundle
+curl -LO https://github.com/txn2/kubefwd/releases/latest/download/kubefwd_checksums.txt
+curl -LO https://github.com/txn2/kubefwd/releases/latest/download/kubefwd_checksums.txt.sigstore.json
+
+# Verify signature
+cosign verify-blob \
+  --bundle kubefwd_checksums.txt.sigstore.json \
+  --certificate-identity-regexp="https://github.com/txn2/kubefwd/.*" \
+  --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
+  kubefwd_checksums.txt
+```
+
+### Verify Docker Images
+
+```bash
+cosign verify txn2/kubefwd:latest \
+  --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
+  --certificate-identity-regexp="https://github.com/txn2/kubefwd/.*"
+```
+
 ## Usage
 
 ### Interactive Mode (Recommended)


### PR DESCRIPTION
Fixes #325: kubefwd_checksums.txt.pem asset missing

Root cause: GoReleaser signs section used ${signature} and ${certificate} template variables without defining the required fields, resulting in empty strings passed to Cosign.

Changes:
- Migrate to Cosign v3 bundle format (.sigstore.json)
- Add signature field to define output filename
- Add verification instructions to README

## Description

The v1.24.0 release notes tell users to verify downloads using:
```bash
cosign verify-blob --signature kubefwd_checksums.txt.sig --certificate kubefwd_checksums.txt.pem ...
```

But the `.pem` certificate file is missing from release assets because the GoReleaser configuration had a bug - it used `${signature}` and `${certificate}` template variables in the cosign args without defining the required `signature:` and `certificate:` fields that populate these variables.

This PR fixes the issue by:
1. Migrating to Cosign v3 bundle format (`.sigstore.json`) - the modern approach that combines signature + certificate into a single file
2. Adding the required `signature:` field to the GoReleaser config
3. Adding correct verification instructions to the README

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Test improvement (new or updated tests)
- [x] Documentation update
- [ ] Stability/performance improvement
- [x] Build/CI improvement

> **Note:** New features are developed by maintainers only. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.

## Related Issues

Fixes #325

## Testing

- [x] Ran `go test ./...` locally
- [ ] Tested manually with a Kubernetes cluster
- [ ] Added new tests for changes (if applicable)

**Additional testing needed:**
- Create a test release (e.g., `v1.24.1-rc1`) and verify the `.sigstore.json` file appears in release assets
- Test the verification command:
  ```bash
  cosign verify-blob \
    --bundle kubefwd_checksums.txt.sigstore.json \
    --certificate-identity-regexp="https://github.com/txn2/kubefwd/.*" \
    --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
    kubefwd_checksums.txt
  ```

## Checklist

- [x] My code follows the project's style guidelines (`go fmt`, `go vet`)
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have updated documentation if needed
- [x] This PR is focused and does not include unrelated changes

## Screenshots/Logs (if applicable)

N/A - Build/CI change. The fix can be verified by checking that future releases include `kubefwd_checksums.txt.sigstore.json` in the release assets.
