### PR TITLE
Fix MCPB build script for goreleaser arm64 directory naming

### DIFF
--- a/mcpb/build.sh
+++ b/mcpb/build.sh
@@ -41,9 +41,10 @@ mkdir -p "$BUILD_DIR"
 
 # Platforms to build for (Claude Desktop supports macOS and Windows)
 # Format: GOOS:GOARCH:goreleaser_dir_suffix
+# Note: goreleaser adds architecture version suffixes (v1 for amd64, v8.0 for arm64)
 PLATFORMS=(
     "darwin:amd64:darwin_amd64_v1"
-    "darwin:arm64:darwin_arm64"
+    "darwin:arm64:darwin_arm64_v8.0"
     "windows:amd64:windows_amd64_v1"
 )
 


### PR DESCRIPTION
GoReleaser uses architecture version suffixes in output directories:
- amd64 → _v1 (GOAMD64 version)
- arm64 → _v8.0 (ARMv8)

The script expected `darwin_arm64` but goreleaser creates `darwin_arm64_v8.0`, causing the release workflow to fail.

## Description

<!-- Brief description of changes. What does this PR do and why? -->

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Test improvement (new or updated tests)
- [ ] Documentation update
- [ ] Stability/performance improvement
- [x] Build/CI improvement

> **Note:** New features are developed by maintainers only. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.

## Related Issues

<!-- Link to issues this PR addresses. Use "Fixes #123" for automatic closing -->

Fixes #

## Testing

<!-- How was this tested? Include steps to reproduce if applicable -->

- [x] Ran `go test ./...` locally
- [ ] Tested manually with a Kubernetes cluster
- [ ] Added new tests for changes (if applicable)

## Checklist

- [ ] My code follows the project's style guidelines (`go fmt`, `go vet`)
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have updated documentation if needed
- [x] This PR is focused and does not include unrelated changes

## Screenshots/Logs (if applicable)

<!-- For TUI changes, error handling improvements, or visual changes -->
