### PR TITLE
MCP Registry Readiness

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,29 @@ jobs:
           curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz
           sudo mv mcp-publisher /usr/local/bin/
 
+      - name: Prepare server.json for MCP Registry
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+
+          # Calculate SHA-256 hashes for each MCPB bundle
+          SHA_DARWIN_ARM64=$(sha256sum dist/mcpb/kubefwd-${VERSION}-darwin-arm64.mcpb | cut -d' ' -f1)
+          SHA_DARWIN_AMD64=$(sha256sum dist/mcpb/kubefwd-${VERSION}-darwin-amd64.mcpb | cut -d' ' -f1)
+          SHA_WINDOWS_AMD64=$(sha256sum dist/mcpb/kubefwd-${VERSION}-windows-amd64.mcpb | cut -d' ' -f1)
+
+          # Update server.json with version and SHA-256 hashes
+          sed -i "s/0.0.0/${VERSION}/g" server.json
+          sed -i "s/kubefwd-0.0.0-darwin-arm64.mcpb/kubefwd-${VERSION}-darwin-arm64.mcpb/" server.json
+          sed -i "s/kubefwd-0.0.0-darwin-amd64.mcpb/kubefwd-${VERSION}-darwin-amd64.mcpb/" server.json
+          sed -i "s/kubefwd-0.0.0-windows-amd64.mcpb/kubefwd-${VERSION}-windows-amd64.mcpb/" server.json
+
+          # Replace placeholder hashes (in order: arm64, amd64, windows)
+          sed -i "0,/PLACEHOLDER_SHA256/{s/PLACEHOLDER_SHA256/${SHA_DARWIN_ARM64}/}" server.json
+          sed -i "0,/PLACEHOLDER_SHA256/{s/PLACEHOLDER_SHA256/${SHA_DARWIN_AMD64}/}" server.json
+          sed -i "0,/PLACEHOLDER_SHA256/{s/PLACEHOLDER_SHA256/${SHA_WINDOWS_AMD64}/}" server.json
+
+          echo "Updated server.json:"
+          cat server.json
+
       - name: Publish to MCP Registry
         run: |
           # Login using GitHub OIDC (id-token: write permission required)
@@ -107,8 +130,6 @@ jobs:
 
           # Publish the server to the MCP registry
           mcp-publisher publish
-        env:
-          # OIDC token is automatically available via ACTIONS_ID_TOKEN_REQUEST_*
 
   provenance:
     needs: [release]

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,8 +9,6 @@ env:
 before:
   hooks:
     - go mod download
-    # Update version in server.json for MCP registry
-    - sed -i'' -e 's/"version": "0.0.0"/"version": "{{ .Version }}"/g' server.json
 
 builds:
   - id: kubefwd

--- a/pkg/fwdapi/logbuffer_test.go
+++ b/pkg/fwdapi/logbuffer_test.go
@@ -266,11 +266,8 @@ func TestGetLogBufferProvider(t *testing.T) {
 		t.Fatal("GetLogBufferProvider returned nil")
 	}
 
-	// Verify it implements the interface
-	_, ok := provider.(types.LogBufferProvider)
-	if !ok {
-		t.Error("GetLogBufferProvider should return a LogBufferProvider")
-	}
+	// Verify we can call methods on the provider (type already enforced by return type)
+	_ = provider.GetLast(10)
 }
 
 func TestInitLogBuffer(t *testing.T) {

--- a/server.json
+++ b/server.json
@@ -9,14 +9,19 @@
   "version": "0.0.0",
   "packages": [
     {
-      "registryType": "docker",
-      "identifier": "txn2/kubefwd",
-      "version": "0.0.0",
-      "transport": {
-        "type": "stdio"
-      },
-      "arguments": ["mcp"],
-      "environmentVariables": []
+      "registryType": "mcpb",
+      "identifier": "https://github.com/txn2/kubefwd/releases/download/v0.0.0/kubefwd-0.0.0-darwin-arm64.mcpb",
+      "file_sha256": "PLACEHOLDER_SHA256"
+    },
+    {
+      "registryType": "mcpb",
+      "identifier": "https://github.com/txn2/kubefwd/releases/download/v0.0.0/kubefwd-0.0.0-darwin-amd64.mcpb",
+      "file_sha256": "PLACEHOLDER_SHA256"
+    },
+    {
+      "registryType": "mcpb",
+      "identifier": "https://github.com/txn2/kubefwd/releases/download/v0.0.0/kubefwd-0.0.0-windows-amd64.mcpb",
+      "file_sha256": "PLACEHOLDER_SHA256"
     }
   ],
   "tags": [


### PR DESCRIPTION
Adds configuration files and CI automation for MCP registry publication.

## Description

This PR enables kubefwd's MCP server to be listed on major MCP registries:

- **`smithery.yaml`** — Configuration for [Smithery.ai](https://smithery.ai) registry with stdio transport and configurable API URL
- **`server.json`** — Metadata for the [Official MCP Registry](https://registry.modelcontextprotocol.io) using MCPB bundles (platform-specific binaries with SHA-256 verification)
- **CI automation** — Release workflow calculates SHA-256 hashes for each MCPB bundle and publishes to the official registry using GitHub OIDC authentication

### Registry Support

| Registry | File | Method |
|----------|------|--------|
| Smithery.ai | `smithery.yaml` | Manual submission |
| Official MCP Registry | `server.json` | Automatic via CI (MCPB bundles) |
| Claude Desktop | `mcpb/manifest.json` | Already supported |

### Why MCPB over Docker?

MCPB bundles are better suited for MCP servers because:
- Direct stdio transport (no container overhead)
- Access to local kubeconfig without volume mounts
- Platform-native binaries with SHA-256 integrity verification

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Test improvement (new or updated tests)
- [ ] Documentation update
- [ ] Stability/performance improvement
- [x] Build/CI improvement

## Testing

- [x] Ran `go test ./...` locally
- [ ] Tested manually with a Kubernetes cluster
- [x] YAML/JSON schema validation passed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] This PR is focused and does not include unrelated changes

## Files Changed

```
smithery.yaml                  (new)  - Smithery.ai configuration
server.json                    (new)  - Official MCP Registry (MCPB)
.github/workflows/release.yml  (mod)  - SHA-256 calculation + mcp-publisher
```
