### PR TITLE
API Documentation Updates

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -308,6 +308,95 @@ Get details for a specific Kubernetes service.
 curl http://kubefwd.internal/api/v1/kubernetes/services/default/api-gateway
 ```
 
+### GET /api/v1/kubernetes/pods/:namespace
+
+List pods in a namespace with status, ready state, restarts, and age.
+
+**Query Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| context | string | Kubernetes context (uses current if omitted) |
+| labelSelector | string | Filter pods by labels (e.g., "app=nginx") |
+| serviceName | string | Filter to pods backing this service |
+
+```bash
+# List all pods in namespace
+curl http://kubefwd.internal/api/v1/kubernetes/pods/default
+
+# Filter by label
+curl "http://kubefwd.internal/api/v1/kubernetes/pods/default?labelSelector=app=nginx"
+
+# Filter by service
+curl "http://kubefwd.internal/api/v1/kubernetes/pods/default?serviceName=api-gateway"
+```
+
+### GET /api/v1/kubernetes/pods/:namespace/:podName
+
+Get detailed pod information including containers, status, conditions, and resources.
+
+```bash
+curl http://kubefwd.internal/api/v1/kubernetes/pods/default/api-gateway-7d4f5b6c8-abc12
+```
+
+### GET /api/v1/kubernetes/pods/:namespace/:podName/logs
+
+Get logs from a pod's container.
+
+**Query Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| context | string | Kubernetes context (uses current if omitted) |
+| container | string | Container name (defaults to first container) |
+| tailLines | integer | Lines from end (default: 100, max: 1000) |
+| sinceTime | string | RFC3339 timestamp to start from |
+| previous | boolean | Get logs from previous container instance |
+| timestamps | boolean | Include timestamps in output |
+
+```bash
+# Get last 100 lines
+curl http://kubefwd.internal/api/v1/kubernetes/pods/default/api-gateway-7d4f5b6c8-abc12/logs
+
+# Get last 50 lines with timestamps
+curl "http://kubefwd.internal/api/v1/kubernetes/pods/default/api-gateway-7d4f5b6c8-abc12/logs?tailLines=50&timestamps=true"
+
+# Get logs from specific container
+curl "http://kubefwd.internal/api/v1/kubernetes/pods/default/api-gateway-7d4f5b6c8-abc12/logs?container=sidecar"
+```
+
+### GET /api/v1/kubernetes/events/:namespace
+
+Get Kubernetes events for debugging. Shows scheduling, pulling, starting, and killing events.
+
+**Query Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| context | string | Kubernetes context (uses current if omitted) |
+| resourceKind | string | Filter by kind (Pod, Service, Deployment) |
+| resourceName | string | Filter by resource name |
+| limit | integer | Max events to return (default: 50) |
+
+```bash
+# Get all events in namespace
+curl http://kubefwd.internal/api/v1/kubernetes/events/default
+
+# Filter to pod events
+curl "http://kubefwd.internal/api/v1/kubernetes/events/default?resourceKind=Pod"
+
+# Get events for specific pod
+curl "http://kubefwd.internal/api/v1/kubernetes/events/default?resourceKind=Pod&resourceName=api-gateway-7d4f5b6c8-abc12"
+```
+
+### GET /api/v1/kubernetes/endpoints/:namespace/:serviceName
+
+Get endpoints for a service. Shows which pods are backing the service and their ready state.
+
+```bash
+curl http://kubefwd.internal/api/v1/kubernetes/endpoints/default/api-gateway
+```
+
 ---
 
 ## Metrics

--- a/docs/mcp-integration.md
+++ b/docs/mcp-integration.md
@@ -231,6 +231,14 @@ That's it. Start talking to your AI about your work.
 - **Get connection info** - Get ready-to-use connection strings, IPs, hostnames, and environment variables
 - **Find services** - Search forwarded services by name pattern, port, or namespace
 
+### Pod Debugging
+
+- **List pods** - See pods with status, ready state, restarts, and age; filter by labels or service
+- **Get pod details** - Inspect containers, conditions, resources, and recent events
+- **Get pod logs** - Stream logs from containers with tail, timestamps, and time filtering
+- **Get Kubernetes events** - View scheduling, pulling, starting events for diagnosing failures
+- **Get service endpoints** - See which pods back a service and their ready state
+
 ### Monitoring & Debugging
 
 - **Quick status** - Fast health check of kubefwd (healthy/degraded/unhealthy)
@@ -264,7 +272,7 @@ The MCP bridge runs without sudo and communicates with kubefwd via REST API. You
 
 For custom integrations, kubefwd MCP provides:
 
-??? note "23 Tools"
+??? note "28 Tools"
 
     | Category | Tools |
     |----------|-------|
@@ -272,6 +280,8 @@ For custom integrations, kubefwd MCP provides:
     | Namespace | `add_namespace`, `remove_namespace` |
     | Service | `add_service`, `remove_service`, `list_services`, `get_service`, `find_services` |
     | Connection | `get_connection_info`, `list_hostnames` |
+    | Pods | `list_pods`, `get_pod`, `get_pod_logs` |
+    | Kubernetes | `get_events`, `get_endpoints` |
     | Health | `get_health`, `get_quick_status`, `get_metrics`, `get_analysis`, `diagnose_errors` |
     | Traffic | `get_http_traffic`, `get_history`, `get_logs` |
     | Control | `reconnect_service`, `reconnect_all_errors`, `sync_service` |

--- a/pkg/fwdapi/handlers/openapi.yaml
+++ b/pkg/fwdapi/handlers/openapi.yaml
@@ -535,6 +535,252 @@ paths:
               schema:
                 $ref: "#/components/schemas/Response"
 
+  /v1/kubernetes/pods/{namespace}:
+    get:
+      tags: [Kubernetes]
+      summary: List pods in a namespace
+      description: Returns pods with status, ready state, restarts, and age. Filter by label selector or service name.
+      operationId: listK8sPods
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          description: Kubernetes namespace
+          schema:
+            type: string
+        - name: context
+          in: query
+          description: Kubernetes context (uses current if omitted)
+          schema:
+            type: string
+        - name: labelSelector
+          in: query
+          description: Label selector to filter pods (e.g., "app=nginx,version=v1")
+          schema:
+            type: string
+        - name: serviceName
+          in: query
+          description: Filter to pods backing this service
+          schema:
+            type: string
+      responses:
+        "200":
+          description: List of pods
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Response"
+        "404":
+          description: Namespace not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /v1/kubernetes/pods/{namespace}/{podName}:
+    get:
+      tags: [Kubernetes]
+      summary: Get pod details
+      description: Returns detailed pod information including containers, status, conditions, resources, and recent events
+      operationId: getK8sPod
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          description: Kubernetes namespace
+          schema:
+            type: string
+        - name: podName
+          in: path
+          required: true
+          description: Pod name
+          schema:
+            type: string
+        - name: context
+          in: query
+          description: Kubernetes context (uses current if omitted)
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Pod details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Response"
+        "404":
+          description: Pod not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /v1/kubernetes/pods/{namespace}/{podName}/logs:
+    get:
+      tags: [Kubernetes]
+      summary: Get pod logs
+      description: Returns log output from a pod's container. Useful for debugging services.
+      operationId: getK8sPodLogs
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          description: Kubernetes namespace
+          schema:
+            type: string
+        - name: podName
+          in: path
+          required: true
+          description: Pod name
+          schema:
+            type: string
+        - name: context
+          in: query
+          description: Kubernetes context (uses current if omitted)
+          schema:
+            type: string
+        - name: container
+          in: query
+          description: Container name (defaults to first container)
+          schema:
+            type: string
+        - name: tailLines
+          in: query
+          description: Number of lines from end (default 100, max 1000)
+          schema:
+            type: integer
+            default: 100
+            maximum: 1000
+        - name: sinceTime
+          in: query
+          description: RFC3339 timestamp to start from (e.g., 2024-01-15T10:30:00Z)
+          schema:
+            type: string
+            format: date-time
+        - name: previous
+          in: query
+          description: Get logs from previous container instance
+          schema:
+            type: boolean
+            default: false
+        - name: timestamps
+          in: query
+          description: Include timestamps in log output
+          schema:
+            type: boolean
+            default: false
+      responses:
+        "200":
+          description: Pod logs
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/Response"
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          podName:
+                            type: string
+                          namespace:
+                            type: string
+                          containerName:
+                            type: string
+                          logs:
+                            type: string
+                          lineCount:
+                            type: integer
+                          truncated:
+                            type: boolean
+        "404":
+          description: Pod not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /v1/kubernetes/events/{namespace}:
+    get:
+      tags: [Kubernetes]
+      summary: Get Kubernetes events
+      description: Returns Kubernetes events for debugging. Shows scheduling, pulling, starting, killing events. Critical for diagnosing startup failures.
+      operationId: getK8sEvents
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          description: Kubernetes namespace
+          schema:
+            type: string
+        - name: context
+          in: query
+          description: Kubernetes context (uses current if omitted)
+          schema:
+            type: string
+        - name: resourceKind
+          in: query
+          description: Filter by resource kind (Pod, Service, Deployment, etc.)
+          schema:
+            type: string
+        - name: resourceName
+          in: query
+          description: Filter by resource name
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: Max events to return (default 50)
+          schema:
+            type: integer
+            default: 50
+      responses:
+        "200":
+          description: Kubernetes events
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Response"
+
+  /v1/kubernetes/endpoints/{namespace}/{serviceName}:
+    get:
+      tags: [Kubernetes]
+      summary: Get service endpoints
+      description: Returns endpoints for a Kubernetes service. Shows which pods are backing the service and their ready state. Useful for debugging service-to-pod routing.
+      operationId: getK8sEndpoints
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          description: Kubernetes namespace
+          schema:
+            type: string
+        - name: serviceName
+          in: path
+          required: true
+          description: Service name
+          schema:
+            type: string
+        - name: context
+          in: query
+          description: Kubernetes context (uses current if omitted)
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Service endpoints
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Response"
+        "404":
+          description: Service or endpoints not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
   /v1/metrics:
     get:
       tags: [Metrics]


### PR DESCRIPTION
- Documented new endpoints for listing pods, retrieving pod details, fetching logs, and viewing Kubernetes events.
- Enhanced OpenAPI spec to include these endpoints, descriptions, and query parameters.
- Updated MCP integration docs and toolset with pod-related operations.
- Increased total MCP tools count to 28.

## Description

This PR adds comprehensive documentation for 5 previously undocumented Kubernetes discovery endpoints and their corresponding MCP tools. These endpoints provide essential pod debugging capabilities that were implemented but not documented.

### New REST API Endpoints Documented

| Endpoint | Description |
|----------|-------------|
| `GET /api/v1/kubernetes/pods/:namespace` | List pods with status, ready state, restarts |
| `GET /api/v1/kubernetes/pods/:namespace/:podName` | Get detailed pod information |
| `GET /api/v1/kubernetes/pods/:namespace/:podName/logs` | Get container logs |
| `GET /api/v1/kubernetes/events/:namespace` | Get Kubernetes events |
| `GET /api/v1/kubernetes/endpoints/:namespace/:serviceName` | Get service endpoints |

### New MCP Tools Documented

| Tool | Description |
|------|-------------|
| `list_pods` | List pods with status and filtering |
| `get_pod` | Get detailed pod information |
| `get_pod_logs` | Stream container logs |
| `get_events` | View Kubernetes events |
| `get_endpoints` | Get service endpoints |

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Test improvement (new or updated tests)
- [x] Documentation update
- [ ] Stability/performance improvement
- [ ] Build/CI improvement

> **Note:** New features are developed by maintainers only. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.

## Related Issues

Fixes #

## Testing

- [ ] Ran `go test ./...` locally
- [ ] Tested manually with a Kubernetes cluster
- [x] Added new tests for changes (if applicable)

Documentation-only changes - no code behavior changes.

## Checklist

- [x] My code follows the project's style guidelines (`go fmt`, `go vet`)
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have updated documentation if needed
- [x] This PR is focused and does not include unrelated changes

## Files Changed

- `pkg/fwdapi/handlers/openapi.yaml` - Added 5 endpoint definitions with parameters and response schemas
- `docs/api-reference.md` - Added documentation with curl examples for 5 endpoints
- `docs/mcp-integration.md` - Updated tool count (23→28), added Pods and Kubernetes categories
