### PR TITLE
ci: fix MCP Registry publish step (fileSha256 field name)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,9 +141,10 @@ jobs:
 
       - name: Validate server.json against MCP schema
         run: |
-          python3 -m pip install --quiet check-jsonschema
-          # JSON Schema validation (types, formats, top-level required fields)
-          check-jsonschema \
+          # JSON Schema validation (types, formats, top-level required fields).
+          # pipx is preinstalled on ubuntu-latest; `pipx run` isolates the tool
+          # in its own venv, sidestepping PEP 668 externally-managed-env issues.
+          pipx run check-jsonschema \
             --schemafile "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json" \
             server.json
           # MCPB contract: every mcpb package must have a real fileSha256.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,6 +139,38 @@ jobs:
           echo "Updated server.json:"
           cat server.json
 
+      - name: Validate server.json against MCP schema
+        run: |
+          python3 -m pip install --quiet check-jsonschema
+          # JSON Schema validation (types, formats, top-level required fields)
+          check-jsonschema \
+            --schemafile "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json" \
+            server.json
+          # MCPB contract: every mcpb package must have a real fileSha256.
+          # The base schema does not enforce this (it's documented-only), so
+          # we check explicitly. Catches wrong field name (file_sha256 vs
+          # fileSha256) and unreplaced PLACEHOLDER_SHA256 values.
+          python3 - <<'PY'
+          import json, re, sys
+          data = json.load(open('server.json'))
+          errors = []
+          for i, pkg in enumerate(data.get('packages', [])):
+              if pkg.get('registryType') != 'mcpb':
+                  continue
+              h = pkg.get('fileSha256')
+              if not h or not re.fullmatch(r'[a-f0-9]{64}', h):
+                  errors.append(
+                      f"packages[{i}] ({pkg.get('identifier','?')}): "
+                      f"missing/invalid fileSha256 (got {h!r})"
+                  )
+          if errors:
+              print('server.json MCPB validation failed:', file=sys.stderr)
+              for e in errors:
+                  print(f'  - {e}', file=sys.stderr)
+              sys.exit(1)
+          print('server.json OK: all mcpb packages have valid fileSha256')
+          PY
+
       - name: Publish to MCP Registry
         run: |
           # Login using GitHub OIDC (id-token: write permission required)

--- a/server.json
+++ b/server.json
@@ -11,7 +11,7 @@
     {
       "registryType": "mcpb",
       "identifier": "https://github.com/txn2/kubefwd/releases/download/v0.0.0/kubefwd-0.0.0-darwin-arm64.mcpb",
-      "file_sha256": "PLACEHOLDER_SHA256",
+      "fileSha256": "PLACEHOLDER_SHA256",
       "transport": {
         "type": "stdio"
       }
@@ -19,7 +19,7 @@
     {
       "registryType": "mcpb",
       "identifier": "https://github.com/txn2/kubefwd/releases/download/v0.0.0/kubefwd-0.0.0-darwin-amd64.mcpb",
-      "file_sha256": "PLACEHOLDER_SHA256",
+      "fileSha256": "PLACEHOLDER_SHA256",
       "transport": {
         "type": "stdio"
       }
@@ -27,7 +27,7 @@
     {
       "registryType": "mcpb",
       "identifier": "https://github.com/txn2/kubefwd/releases/download/v0.0.0/kubefwd-0.0.0-windows-amd64.mcpb",
-      "file_sha256": "PLACEHOLDER_SHA256",
+      "fileSha256": "PLACEHOLDER_SHA256",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary

The Release workflow has been failing at the **Publish to MCP Registry** step on every release since v1.25.1 (13 consecutive runs). For v1.25.13, the failed workflow was re-run, which re-invoked GoReleaser with `--clean` — producing non-reproducible Go binaries — while the `txn2/homebrew-tap` formula committed during the first run still pinned the old SHAs. Result: `brew install txn2/tap/kubefwd` is broken on every platform for v1.25.13 (see txn2/homebrew-tap#5).

## Root cause

`server.json` used the snake_case key `file_sha256`, but the MCP registry schema at `static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json` requires camelCase `fileSha256`. The registry returned:

```
registry validation failed for package 0 ...: must include a fileSha256 hash for integrity verification
```

The sed step was populating correct hashes, just under the wrong key — so the registry saw them as missing.

## Changes

- **`server.json`**: rename `file_sha256` → `fileSha256` in all three MCPB package entries.
- **`.github/workflows/release.yml`**: add a "Validate server.json against MCP schema" step between Prepare and Publish. It runs:
  1. `pipx run check-jsonschema` against the official schema for general structure.
  2. An explicit **MCPB contract check** (pure-Python stdlib) asserting every `registryType: mcpb` package has a `fileSha256` matching `^[a-f0-9]{64}$`. The base schema documents this requirement but does not enforce it, so we do — this is what actually catches the class of bug we just hit.

## Why this matters beyond one step

The MCP publish failure was itself benign (MCP registry publish is the last step), but its repeated failure trained a reflex to re-run the workflow. Re-running GoReleaser is **destructive**: Go builds aren't byte-reproducible across invocations, so every retry produces new binaries that no longer match the homebrew formula committed by the first run. Fixing the publish step removes the trigger and the temptation.

## Test plan

- [x] Verified field name against the published schema (`fileSha256`, pattern `^[a-f0-9]{64}$`)
- [x] Simulated the full sed populate → validate pipeline locally; populated `server.json` passes both checks
- [x] Verified validator fails cleanly on the v1.25.13 bug pattern (snake_case key) and on unreplaced `PLACEHOLDER_SHA256`
- [x] Confirmed `pipx` is preinstalled on `ubuntu-latest`; using `pipx run` avoids PEP 668 externally-managed-env issues
- [ ] Cut v1.25.14 after merge and confirm Release workflow runs green end-to-end without re-run

## Not in scope

This PR does **not** fix the underlying fragility that any post-GoReleaser failure + a re-run click will reproduce the SHA-drift bug. Suggested follow-ups (separate PRs):

- Guard GoReleaser step with `if: github.run_attempt == 1` or similar, so re-runs skip rebuild
- Split GoReleaser into its own job that can't be re-invoked
- Pin `-buildid=` to make Go builds reproducible across invocations

Fixes: txn2/homebrew-tap#5