### PR TITLE
docs: PR #473 review fixes + local DESIGN.md adoption record

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,243 @@
+---
+version: alpha
+spec: https://github.com/google-labs-code/design.md
+name: kubefwd-docs
+description: Local design adoption record for the kubefwd.com documentation site. References txn2/www DESIGN.md as the canonical visual identity for tokens, typography, components, copyright voice, and accessibility rules. Records only the decisions and MkDocs Material learnings that the canonical does not cover.
+upstream:
+  design: https://github.com/txn2/www/blob/master/DESIGN.md
+  tokens: https://github.com/txn2/www/blob/master/tokens.json
+adoption: token-alignment
+stack:
+  generator: MkDocs
+  theme: Material for MkDocs
+  templates: docs/overrides/
+  styles: docs/stylesheets/extra.css
+---
+
+## What is canonical
+
+The canonical visual identity for txn2 lives in [`txn2/www/DESIGN.md`](https://github.com/txn2/www/blob/master/DESIGN.md) with tokens in [`txn2/www/tokens.json`](https://github.com/txn2/www/blob/master/tokens.json). This file defers to those for everything below. If a value here disagrees with upstream, upstream wins.
+
+| Concern              | Source of truth |
+|----------------------|-----------------|
+| Color palette        | upstream `tokens.json` `color.*` |
+| Typography stack     | upstream `tokens.json` `font.*` |
+| Type scale           | upstream `DESIGN.md` Typography table |
+| Spacing / measure    | upstream `tokens.json` `size.*` |
+| Component contracts  | upstream `DESIGN.md` Components |
+| Voice / copy rules   | upstream `DESIGN.md` Voice and Copy |
+| Accessibility rules  | upstream `DESIGN.md` Do's and Don'ts |
+| Mermaid theme        | upstream `DESIGN.md` `mcp__card--feature` block |
+
+Tokens are mirrored as CSS custom properties in `docs/stylesheets/extra.css` `:root`. They are duplicated for runtime use, not as a divergence point. When upstream changes a token, update the value in `extra.css` and ship.
+
+## Adoption level: token alignment
+
+Per the upstream downstream contract, three levels are valid:
+
+1. Reference. Link to upstream, no visual changes.
+2. Token alignment. Keep MkDocs Material, re-skin via `extra.css` against upstream tokens.
+3. Full re-skin. Replace MkDocs Material with custom layouts.
+
+kubefwd runs at **level 2**. The site keeps Material's instant nav, search, sidebar, version selector, code copy, and content extensions. The visual layer is replaced. The homepage is a custom Material template that takes over `block header`, `block container`, and `block footer` for full-bleed treatment.
+
+## File map
+
+| Path | Role |
+|------|------|
+| `mkdocs.yml`                   | Single dark `slate` palette. `font: false` so CSS loads the upstream Google Fonts URL with trimmed axes. |
+| `docs/index.md`                | Stub front matter with `template: home.html`. All homepage HTML lives in the template. |
+| `docs/overrides/main.html`     | Adds the upstream Google Fonts `<link>` plus OG and Twitter meta. Inherited by every page. |
+| `docs/overrides/home.html`     | Custom homepage template. Overrides `block header` (rail), `block tabs` (empty), `block container` (page--home shell with hero, sections, flagship cards, stack, coda), `block footer` (home-footer). |
+| `docs/stylesheets/extra.css`   | All design rules. Two halves: homepage components scoped under `.page--home`, and Material chrome restyle for inner pages via `[data-md-color-scheme="slate"]` variable overrides. |
+
+## Project-specific components
+
+Components ported from upstream verbatim, with kubefwd content:
+
+- `.rail` (replaces Material `.md-header` on the homepage). Brand links to `./`. Live UTC clock in meta. txn2.com link in meta as `part of <em class="serif">txn2</em> ↗`.
+- `.hero` with three Fraunces rows (kubefwd / kubernetes / port forwards.).
+- `.section`, `.section__index`, `.section__title`.
+- `.flagship__card`. Two cards: `--kubefwd` (TUI mode demo) and a second variant for the API + MCP surfaces. Top accent line animates on hover per upstream spec.
+- `.terminal`, `.terminal__bar`, `.terminal__body` with `.t-prompt`, `.t-ok`, `.t-mute` classes. The only block with shadow.
+- `.stack`, `.stack__row`. Each row links to a real anchor in the docs (architecture/#ip-allocation, advanced-usage/#custom-hosts-file-path, user-guide/#auto-reconnect, user-guide/#interface-overview, api-reference/, mcp-integration/).
+- `.coda` and `.home-footer` (renamed from upstream `.footer` to avoid collision with markdown that uses `class="footer"`; see Learning #5).
+
+Components from upstream **not used** here, with reason:
+
+- `.mcp__card--feature` and the MCP grid. kubefwd is a single project, not an MCP catalog.
+- The `mcp-data-platform` mermaid hero. Not relevant.
+- The 5-column footer's `sponsors / craig` columns. The kubefwd home-footer has `about / docs / interfaces / code / txn2 / org` columns instead, since this site is project-scoped.
+
+Custom additions specific to kubefwd:
+
+- `home-footer__col--meta` includes a `txn2 / org` panel that backlinks to txn2.com explicitly. Per the org-wide rule that every sister project must clearly link home.
+- All CNCF Landscape mentions on the homepage and in `docs/attributions.md` link to the kubefwd entry on `landscape.cncf.io`. The Landscape listing is a load-bearing credential and earns a real link wherever it appears.
+
+## MkDocs Material learnings
+
+The upstream is built with Hugo. kubefwd is built with MkDocs Material. The two have different override surfaces, so the same visual outcome requires different mechanics. These are the lessons worth carrying forward when re-skinning the next sister project.
+
+### 1. Override the homepage via a separate template, not via CSS hacks
+
+MkDocs Material's content pipeline wraps every page body in `.md-content__inner` with hard-coded max-widths. Trying to break out with `:has()` selectors or full-bleed hacks inside the markdown body is fragile and fights Material's own layout.
+
+The pattern that works: create `docs/overrides/home.html` that extends Material's `main.html` and overrides `block container`, `block header`, `block footer`. Set `template: home.html` in `docs/index.md` front matter. Material then renders the homepage with the custom blocks instead of the standard layout. The homepage gets full viewport control without any width-fighting.
+
+```yaml
+# docs/index.md
+---
+title: kubefwd
+template: home.html
+hide:
+  - navigation
+  - toc
+  - footer
+---
+```
+
+### 2. Re-skin inner pages via Material variable overrides
+
+Material exposes its own design tokens as CSS custom properties on `[data-md-color-scheme="slate"]`. Mapping these to upstream tokens re-skins every inner page automatically without touching their markdown:
+
+```css
+[data-md-color-scheme="slate"] {
+  --md-default-bg-color:        var(--ink);
+  --md-default-fg-color:        var(--paper);
+  --md-typeset-a-color:         var(--signal);
+  --md-text-font:               var(--sans);
+  --md-code-font:               var(--mono);
+  /* ...etc */
+}
+```
+
+Verify the body actually carries the attribute (`grep data-md-color-scheme site/getting-started/index.html`). Single-scheme palettes (`palette: scheme: slate`) do emit it. If they ever stop, fall back to `:root`.
+
+### 3. `font: false` to load fonts directly from CSS
+
+Material's `font:` directive loads fonts through Google Fonts but without axis control. To get the upstream's exact trimmed payload (Fraunces with `opsz/wght` italic axis, Instrument Sans roman 400-700, JetBrains Mono roman 400-700, **no SOFT axis**), set `font: false` in `mkdocs.yml` and load the upstream Google Fonts URL via a `<link>` in `main.html`'s `extrahead` block. Verify a single `fonts.googleapis.com` request in DevTools.
+
+### 4. Scope every homepage component class under `.page--home`
+
+The upstream uses `<main class="page page--home">` on its index page and inner pages don't inherit those classes. In MkDocs the same component class names will collide if any markdown happens to use `class="terminal"`, `class="footer"`, `class="section"`, etc. Material's admonitions, tabbed content, and `md_in_html` all generate divs with predictable class names, and contributors will write more.
+
+Discipline: every homepage component rule must include `.page--home` as an ancestor, OR rename the class with a project-specific prefix (e.g., `home-footer`). The cost of getting this wrong is silent visual breakage on inner pages weeks later when someone uses one of the colliding names.
+
+### 5. Rename `.footer` → `.home-footer`
+
+The single most common collision. Markdown that includes a literal `<div class="footer">` is plausible and will inherit the homepage's 60px-padded, 5-column-grid footer styling. Rename rather than scope.
+
+### 6. h3 and h4 are technical reference, not display type
+
+Inner pages like `api-reference.md` use `### GET /api/health` and `### POST /api/v1/services` as section headings. Rendering these in Fraunces italic display style (the obvious choice for a "serif headings" design) makes the API reference unreadable.
+
+The rule: h1 and h2 stay Fraunces italic for page and section titles. h3 and h4 switch to Instrument Sans bold so technical reference reads as text, not as type. Add a `:has(code)` block that flips any heading containing inline code to JetBrains Mono with signal-orange code text. Add a `@supports not selector(:has(*))` fallback for older browsers.
+
+```css
+.md-typeset h3 {
+  font-family: var(--sans);
+  font-weight: 700;
+  font-size: clamp(18px, 1.6vw, 22px);
+}
+.md-typeset h1:has(code),
+.md-typeset h2:has(code),
+.md-typeset h3:has(code),
+.md-typeset h4:has(code) {
+  font-family: var(--mono);
+  font-style: normal;
+  font-weight: 700;
+}
+```
+
+### 7. Tabbed content nests boxes, fix it
+
+Material's `.md-typeset .tabbed-set` defaults to a bordered, backgrounded box. Code blocks inside also default to bordered backgrounded boxes. The result is nested rectangles with cluttered visual hierarchy.
+
+The fix: strip the `.tabbed-set` background and border. Leave only a bottom underline on `.tabbed-labels`. Let the inner code blocks be the visual statement. Tighten `pre > code` padding to ~14px so single-line install commands don't render as 70px-tall rectangles.
+
+### 8. Mermaid via Material's CSS variables, not via separate init
+
+MkDocs Material includes a Mermaid integration that reads `--md-mermaid-*` CSS variables. Don't bring in `mermaid.esm.mjs` separately like the upstream Hugo site does. Instead, set the variables in the slate scheme block:
+
+```css
+[data-md-color-scheme="slate"] {
+  --md-mermaid-node-bg-color:   var(--ink-3);
+  --md-mermaid-node-fg-color:   var(--paper);
+  --md-mermaid-edge-color:      var(--mute);
+  /* ...full list in extra.css */
+}
+```
+
+Plus a `.md-typeset .mermaid` container restyle (dashed border, ink-3 background) for the diagram block itself.
+
+### 9. Guard inline scripts against `navigation.instant`
+
+`navigation.instant` is enabled (`mkdocs.yml`). On every navigation back to the homepage, Material rehydrates the body. Any `setInterval`, `setTimeout`, or event listener registered in an inline `<script>` will register **again**, leaking handles indefinitely.
+
+Pattern for the live UTC clock used in the rail and footer:
+
+```html
+<script>
+  (function () {
+    if (window.__kubefwdClock) {
+      window.__kubefwdClock.tick();
+      return;
+    }
+    function tick() { /* ... */ }
+    tick();
+    var handle = setInterval(tick, 30 * 1000);
+    window.__kubefwdClock = { tick: tick, handle: handle };
+  })();
+</script>
+```
+
+The `tick()` call on re-entry refreshes the displayed time without registering a new interval.
+
+### 10. Drop the light/dark toggle
+
+The canonical txn2 identity is dark only. Collapse `palette` to a single `scheme: slate`. Remove the `toggle:` blocks. Audit `extra.css` and `index.md` for orphan light-mode references (`hero-logo-light`, `prefers-color-scheme: light`, `kf-green` etc).
+
+### 11. Atmospheric overlays at low z-index
+
+`body::before` (grain) and `body::after` (vignette) are fixed viewport overlays. Place them at `z-index: 1` so they sit above the page background but below the rail (z-50) and skiplink (z-200). Vignette has no blend mode, so a higher z-index would darken interactive chrome.
+
+### 12. What Hugo does that MkDocs cannot match
+
+For reference when the next sister project chooses its adoption level:
+
+- Hugo can compile tokens.json into CSS custom properties at build time via `resources.Get` + `transform.Unmarshal`. MkDocs has no equivalent. We hand-mirror the tokens in `extra.css` `:root` and update them when upstream changes.
+- Hugo can subscribe to upstream tokens through a small extra.css that imports a generated `:root { --... }` block. MkDocs cannot. Token sync is a manual PR.
+- Hugo's partial system handles header/footer composition naturally. MkDocs uses Material template `{% block %}` overrides, which is similar but constrained to Material's block names (`announce`, `header`, `tabs`, `container`, `content`, `footer`, `scripts`).
+
+## Voice and copy
+
+Defers to upstream. Briefly:
+
+- No em-dashes (U+2014) or en-dashes (U+2013) anywhere, including code comments and template comments. Use commas, periods, colons, parentheses, slashes, hyphens.
+- No AI-tell vocabulary: `seamless`, `leverage`, `comprehensive`, `robust`, `delve`, `unleash`, `elevate`, `embark`, `tapestry`, `not just X but Y`, `as an AI`, `let me X`.
+- Sentence case for body. Lowercase for rail and label text. Title case rare.
+- Section indices: `§ 01 / title` with slash, never an em-dash.
+- Year ranges use a hyphen: `2017-2026`.
+- Verify before commit: `grep -RE "—|–" docs/ mkdocs.yml`.
+
+## Updating
+
+When the upstream `txn2/www/DESIGN.md` or `tokens.json` changes:
+
+1. Read the upstream diff. Identify which tokens, components, or rules changed.
+2. Update the matching CSS variables in `docs/stylesheets/extra.css` `:root`.
+3. If a component contract changed (padding, border, hover behavior), update the homepage template in `docs/overrides/home.html` and the matching CSS rules.
+4. Update this file's File map / Project-specific components / MkDocs Material learnings sections if a new learning emerges.
+5. Run `mkdocs build --strict` and verify in the browser before committing. Verify the home page hero, flagship cards, terminal, stack, coda, and home-footer. Verify an inner page (`/getting-started/`, `/api-reference/`) still inherits the look.
+
+Keep this file thin. If a section grows past 30 lines, ask whether it belongs upstream instead.
+
+## Downstream contract for sister projects
+
+This file is canonical only for kubefwd.com. Other sister projects (txeh, mcp-s3, mcp-trino, mcp-datahub, mcp-data-platform) considering the same adoption should:
+
+1. Use this file as a template for their own thin local DESIGN.md.
+2. Reference upstream `txn2/www/DESIGN.md` as the source of truth for tokens, typography, components, voice.
+3. Replace the kubefwd-specific sections (project-specific components, file paths, custom additions) with their own.
+4. Keep the MkDocs Material learnings section. Those apply to every MkDocs Material project.
+5. Update upstream's downstream-contract list when adding a new project.

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -301,18 +301,19 @@
 </main>
 {% endblock %}
 
-{# Custom homepage footer replaces Material's. #}
+{# Custom homepage footer replaces Material's. Class names prefixed
+   home-footer to avoid global collision with markdown class="footer". #}
 {% block footer %}
-<footer class="footer">
-  <div class="footer__rule" aria-hidden="true"></div>
-  <div class="footer__inner">
-    <div class="footer__col">
-      <p class="footer__label">about</p>
-      <p class="footer__text">A bulk Kubernetes service port-forwarder by <a href="https://imti.co">Craig Johnston</a>, part of the <a href="https://txn2.com">txn2</a> open source organization, sponsored by <a href="https://deasil.works">Deasil Works, Inc.</a> and <a href="https://plexara.io">Plexara</a>.</p>
+<footer class="home-footer">
+  <div class="home-footer__rule" aria-hidden="true"></div>
+  <div class="home-footer__inner">
+    <div class="home-footer__col">
+      <p class="home-footer__label">about</p>
+      <p class="home-footer__text">A bulk Kubernetes service port-forwarder by <a href="https://imti.co">Craig Johnston</a>, part of the <a href="https://txn2.com">txn2</a> open source organization, sponsored by <a href="https://deasil.works">Deasil Works, Inc.</a> and <a href="https://plexara.io">Plexara</a>.</p>
     </div>
-    <div class="footer__col">
-      <p class="footer__label">docs</p>
-      <ul class="footer__links">
+    <div class="home-footer__col">
+      <p class="home-footer__label">docs</p>
+      <ul class="home-footer__links">
         <li><a href="getting-started/">getting started</a></li>
         <li><a href="user-guide/">user guide</a></li>
         <li><a href="configuration/">configuration</a></li>
@@ -320,34 +321,34 @@
         <li><a href="troubleshooting/">troubleshooting</a></li>
       </ul>
     </div>
-    <div class="footer__col">
-      <p class="footer__label">interfaces</p>
-      <ul class="footer__links">
+    <div class="home-footer__col">
+      <p class="home-footer__label">interfaces</p>
+      <ul class="home-footer__links">
         <li><a href="api-reference/">rest api</a></li>
         <li><a href="mcp-integration/">mcp integration</a></li>
         <li><a href="architecture/">architecture</a></li>
         <li><a href="comparison/">comparison</a></li>
       </ul>
     </div>
-    <div class="footer__col">
-      <p class="footer__label">code</p>
-      <ul class="footer__links">
+    <div class="home-footer__col">
+      <p class="home-footer__label">code</p>
+      <ul class="home-footer__links">
         <li><a href="https://github.com/txn2/kubefwd">github.com/txn2/kubefwd</a></li>
         <li><a href="https://github.com/txn2/kubefwd/releases">releases</a></li>
         <li><a href="https://hub.docker.com/r/txn2/kubefwd">docker hub</a></li>
         <li><a href="https://github.com/txn2/kubefwd/issues">issues</a></li>
       </ul>
     </div>
-    <div class="footer__col footer__col--meta">
-      <p class="footer__label">txn2 / org</p>
-      <p class="footer__text"><a href="https://txn2.com">txn2.com&nbsp;↗</a><br>
-      <span class="footer__links__sub">canonical home of the txn2 open source organization</span></p>
-      <p class="footer__mono">apache 2.0 license <span class="dot">·</span> <span data-clock>·· UTC</span></p>
+    <div class="home-footer__col home-footer__col--meta">
+      <p class="home-footer__label">txn2 / org</p>
+      <p class="home-footer__text"><a href="https://txn2.com">txn2.com&nbsp;↗</a><br>
+      <span class="home-footer__links__sub">canonical home of the txn2 open source organization</span></p>
+      <p class="home-footer__mono">apache 2.0 license <span class="dot">·</span> <span data-clock>·· UTC</span></p>
     </div>
   </div>
-  <div class="footer__base">
+  <div class="home-footer__base">
     <p>© 2017-2026 · <a href="https://txn2.com">txn2</a> · kubefwd released under Apache 2.0.</p>
-    <p class="footer__base__tag"><a href="https://txn2.com">design · txn2.com&nbsp;↗</a></p>
+    <p class="home-footer__base__tag"><a href="https://txn2.com">design · txn2.com&nbsp;↗</a></p>
   </div>
 </footer>
 {% endblock %}
@@ -356,7 +357,14 @@
 {{ super() }}
 <script>
   // Live UTC clock for rail/footer.
+  // Guarded against duplicate registration: Material's instant-nav rehydrates
+  // the body on every navigation back to the homepage; without this guard a
+  // fresh setInterval handle leaks each visit.
   (function () {
+    if (window.__kubefwdClock) {
+      window.__kubefwdClock.tick();
+      return;
+    }
     function tick() {
       var now = new Date();
       var hh = String(now.getUTCHours()).padStart(2, '0');
@@ -367,7 +375,8 @@
       });
     }
     tick();
-    setInterval(tick, 30 * 1000);
+    var handle = setInterval(tick, 30 * 1000);
+    window.__kubefwdClock = { tick: tick, handle: handle };
   })();
 </script>
 {% endblock %}

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -91,6 +91,35 @@
   --md-shadow-z1: 0 1px 0 rgba(255,255,255,0.02);
   --md-shadow-z2: 0 1px 0 rgba(255,255,255,0.02);
   --md-shadow-z3: 0 1px 0 rgba(255,255,255,0.02);
+
+  /* Mermaid theme variables consumed by MkDocs Material's
+     Mermaid integration. Mirrors the txn2 DESIGN.md Mermaid block. */
+  --md-mermaid-font-family:                 var(--mono);
+  --md-mermaid-edge-color:                  var(--mute);
+  --md-mermaid-node-bg-color:               var(--ink-3);
+  --md-mermaid-node-fg-color:               var(--paper);
+  --md-mermaid-label-bg-color:              var(--ink-3);
+  --md-mermaid-label-fg-color:              var(--paper);
+  --md-mermaid-sequence-actor-bg-color:     var(--ink-3);
+  --md-mermaid-sequence-actor-fg-color:     var(--paper);
+  --md-mermaid-sequence-actor-border-color: var(--rule-2);
+  --md-mermaid-sequence-actor-line-color:   var(--rule-2);
+  --md-mermaid-sequence-actorman-bg-color:  var(--ink-3);
+  --md-mermaid-sequence-actorman-line-color: var(--mute);
+  --md-mermaid-sequence-box-bg-color:       var(--ink-2);
+  --md-mermaid-sequence-box-fg-color:       var(--paper);
+  --md-mermaid-sequence-label-bg-color:     var(--ink-2);
+  --md-mermaid-sequence-label-fg-color:     var(--mute);
+  --md-mermaid-sequence-loop-bg-color:      var(--ink-2);
+  --md-mermaid-sequence-loop-fg-color:      var(--paper);
+  --md-mermaid-sequence-loop-border-color:  var(--rule-2);
+  --md-mermaid-sequence-message-fg-color:   var(--paper-dim);
+  --md-mermaid-sequence-message-line-color: var(--mute);
+  --md-mermaid-sequence-note-bg-color:      var(--ink-2);
+  --md-mermaid-sequence-note-fg-color:      var(--paper);
+  --md-mermaid-sequence-note-border-color:  var(--signal);
+  --md-mermaid-sequence-number-bg-color:    var(--signal);
+  --md-mermaid-sequence-number-fg-color:    var(--ink);
 }
 
 /* ──────────────────────────────────────────────────────────────
@@ -153,6 +182,10 @@ em.serif { font-family: var(--serif); font-style: italic; font-weight: 400; }
 
 /* ──────────────────────────────────────────────────────────────
    FILM GRAIN + VIGNETTE / fixed viewport overlays, page-wide
+   z-index 1: above the page background, below the rail (z 50),
+   skiplink (z 200), and any interactive Material chrome. The
+   grain uses overlay blend so it stays subtle even over text;
+   the vignette only dims the corners.
    ────────────────────────────────────────────────────────────── */
 
 body::before,
@@ -161,7 +194,7 @@ body::after {
   position: fixed;
   inset: 0;
   pointer-events: none;
-  z-index: 100;
+  z-index: 1;
 }
 body::before {
   opacity: .08;
@@ -339,6 +372,8 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
 
 /* ──────────────────────────────────────────────────────────────
    HERO
+   All rules scoped under .page--home so component classes never
+   leak into Material-rendered inner pages.
    ────────────────────────────────────────────────────────────── */
 
 .page--home .hero {
@@ -348,7 +383,7 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
   margin: 0 auto;
 }
 
-.hero__stamp {
+.page--home .hero__stamp {
   position: absolute;
   top: clamp(40px, 8vh, 90px);
   right: var(--gutter);
@@ -362,10 +397,10 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
   padding-right: 14px;
   animation: rise 1.1s .1s both ease-out;
 }
-.hero__stamp__line { line-height: 1.7; }
-.hero__stamp__line--ok { color: var(--signal); }
+.page--home .hero__stamp__line { line-height: 1.7; }
+.page--home .hero__stamp__line--ok { color: var(--signal); }
 
-.hero__display {
+.page--home .hero__display {
   font-family: var(--serif);
   font-weight: 300;
   font-size: clamp(60px, 12.5vw, 220px);
@@ -374,32 +409,32 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
   margin-bottom: 56px;
   font-variation-settings: "opsz" 144;
 }
-.hero__row {
+.page--home .hero__row {
   display: flex; align-items: baseline; gap: clamp(12px, 2vw, 36px);
   flex-wrap: wrap;
 }
-.hero__row--1 { animation: rise 1.1s .25s both ease-out; }
-.hero__row--2 {
+.page--home .hero__row--1 { animation: rise 1.1s .25s both ease-out; }
+.page--home .hero__row--2 {
   padding-left: clamp(40px, 14vw, 240px);
   animation: rise 1.1s .4s both ease-out;
 }
-.hero__row--3 {
+.page--home .hero__row--3 {
   padding-left: clamp(20px, 6vw, 100px);
   animation: rise 1.1s .55s both ease-out;
 }
-.hero__row em.serif {
+.page--home .hero__row em.serif {
   font-style: italic;
   color: var(--paper);
   font-variation-settings: "opsz" 144;
 }
-.outline {
+.page--home .outline {
   -webkit-text-stroke: 1.5px var(--paper);
   color: transparent;
   font-style: normal;
   font-weight: 400;
   font-family: var(--serif);
 }
-.hero__chip {
+.page--home .hero__chip {
   font-family: var(--mono);
   font-size: 13px;
   letter-spacing: 0.04em;
@@ -414,7 +449,7 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
   white-space: nowrap;
 }
 
-.hero__intro {
+.page--home .hero__intro {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: clamp(24px, 5vw, 80px);
@@ -425,16 +460,16 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
   padding-left: clamp(20px, 14vw, 240px);
   animation: rise 1.1s .8s both ease-out;
 }
-.hero__lede {
+.page--home .hero__lede {
   font-size: clamp(15px, 1.1vw, 18px);
   line-height: 1.6;
   color: var(--paper-dim);
   max-width: 48ch;
 }
-.hero__lede strong { color: var(--paper); font-weight: 600; }
-.hero__lede a { color: var(--signal); border-bottom: 1px solid var(--rule); }
-.hero__lede a:hover { color: var(--signal-2); border-color: var(--signal-2); }
-.hero__lede code {
+.page--home .hero__lede strong { color: var(--paper); font-weight: 600; }
+.page--home .hero__lede a { color: var(--signal); border-bottom: 1px solid var(--rule); }
+.page--home .hero__lede a:hover { color: var(--signal-2); border-color: var(--signal-2); }
+.page--home .hero__lede code {
   font-family: var(--mono);
   font-size: 0.9em;
   color: var(--signal-2);
@@ -442,9 +477,9 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
   border-radius: 2px;
   padding: 1px 5px;
 }
-.hero__lede--muted { color: var(--mute); }
+.page--home .hero__lede--muted { color: var(--mute); }
 
-.dropcap {
+.page--home .dropcap {
   font-family: var(--serif);
   font-style: italic;
   font-size: 3.4em;
@@ -457,20 +492,20 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
 }
 
 @media (max-width: 760px) {
-  .hero__stamp {
+  .page--home .hero__stamp {
     position: static; text-align: left;
     border-right: 0;
     border-left: 1px solid var(--signal);
     padding-right: 0; padding-left: 14px;
     margin-bottom: 36px;
   }
-  .hero__intro { grid-template-columns: 1fr; padding-left: 0; }
-  .hero__row--2, .hero__row--3 { padding-left: 0; }
-  .hero__chip { display: none; }
+  .page--home .hero__intro { grid-template-columns: 1fr; padding-left: 0; }
+  .page--home .hero__row--2, .page--home .hero__row--3 { padding-left: 0; }
+  .page--home .hero__chip { display: none; }
 }
 
 /* Ticker */
-.hero__ticker {
+.page--home .hero__ticker {
   margin-top: 80px;
   border-top: 1px solid var(--rule);
   border-bottom: 1px solid var(--rule);
@@ -479,8 +514,8 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
   position: relative;
   animation: rise 1.1s 1s both ease-out;
 }
-.ticker { overflow: hidden; }
-.ticker__track {
+.page--home .ticker { overflow: hidden; }
+.page--home .ticker__track {
   display: flex; gap: 30px;
   white-space: nowrap;
   animation: ticker 60s linear infinite;
@@ -490,8 +525,8 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
   color: var(--mute);
   text-transform: lowercase;
 }
-.ticker__track span { color: var(--paper-dim); }
-.ticker__track span:nth-child(even) { color: var(--signal); }
+.page--home .ticker__track span { color: var(--paper-dim); }
+.page--home .ticker__track span:nth-child(even) { color: var(--signal); }
 @keyframes ticker { from { transform: translateX(0); } to { transform: translateX(-50%); } }
 
 @keyframes rise {
@@ -510,11 +545,11 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
   margin: 0 auto;
 }
 
-.section__head {
+.page--home .section__head {
   max-width: 1100px;
   margin-bottom: 64px;
 }
-.section__index {
+.page--home .section__index {
   font-family: var(--mono);
   font-size: 11px;
   letter-spacing: 0.18em;
@@ -524,7 +559,7 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
   padding-bottom: 14px;
   border-bottom: 1px solid var(--rule);
 }
-.section__title {
+.page--home .section__title {
   font-family: var(--serif);
   font-weight: 300;
   font-size: clamp(36px, 5.5vw, 76px);
@@ -534,14 +569,14 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
   font-variation-settings: "opsz" 144;
   margin-bottom: 24px;
 }
-.section__title em.serif { color: var(--signal); font-style: italic; }
-.section__lede {
+.page--home .section__title em.serif { color: var(--signal); font-style: italic; }
+.page--home .section__lede {
   color: var(--paper-dim);
   max-width: 64ch;
   font-size: 17px;
   line-height: 1.6;
 }
-.section__lede code {
+.page--home .section__lede code {
   font-family: var(--mono);
   font-size: 0.9em;
   color: var(--signal-2);
@@ -554,16 +589,16 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
    FLAGSHIP CARDS
    ────────────────────────────────────────────────────────────── */
 
-.flagship {
+.page--home .flagship {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 28px;
 }
 @media (max-width: 980px) {
-  .flagship { grid-template-columns: 1fr; }
+  .page--home .flagship { grid-template-columns: 1fr; }
 }
 
-.flagship__card {
+.page--home .flagship__card {
   position: relative;
   background: var(--ink-2);
   border: 1px solid var(--rule);
@@ -571,7 +606,7 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
   overflow: hidden;
   transition: border-color .35s ease, transform .35s ease;
 }
-.flagship__card::before {
+.page--home .flagship__card::before {
   content: "";
   position: absolute;
   top: 0; left: 0;
@@ -579,11 +614,11 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
   background: var(--signal);
   transition: width .5s cubic-bezier(.2,.8,.2,1);
 }
-.flagship__card:hover { border-color: var(--rule-2); transform: translateY(-3px); }
-.flagship__card:hover::before { width: 100%; }
+.page--home .flagship__card:hover { border-color: var(--rule-2); transform: translateY(-3px); }
+.page--home .flagship__card:hover::before { width: 100%; }
 
-.flagship__head { margin-bottom: 18px; }
-.flagship__id {
+.page--home .flagship__head { margin-bottom: 18px; }
+.page--home .flagship__id {
   font-family: var(--mono);
   font-size: 11px;
   letter-spacing: 0.16em;
@@ -591,15 +626,15 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
   color: var(--mute);
   margin-bottom: 14px;
 }
-.flagship__url {
+.page--home .flagship__url {
   color: var(--signal);
   border-bottom: 1px solid transparent;
   transition: border-color .2s, color .2s;
   text-transform: lowercase;
   letter-spacing: 0.06em;
 }
-.flagship__url:hover { color: var(--signal-2); border-bottom-color: var(--signal-2); }
-.flagship__name {
+.page--home .flagship__url:hover { color: var(--signal-2); border-bottom-color: var(--signal-2); }
+.page--home .flagship__name {
   font-family: var(--serif);
   font-weight: 300;
   font-style: italic;
@@ -610,28 +645,28 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
   font-variation-settings: "opsz" 144;
   margin-bottom: 12px;
 }
-.flagship__tag {
+.page--home .flagship__tag {
   font-family: var(--sans);
   color: var(--paper-dim);
   font-size: 18px;
   line-height: 1.4;
   max-width: 40ch;
 }
-.flagship__tag code {
+.page--home .flagship__tag code {
   font-size: .92em;
   color: var(--signal);
   background: rgba(255,90,31,0.08);
   padding: 1px 6px;
   border-radius: 2px;
 }
-.flagship__body p {
+.page--home .flagship__body p {
   color: var(--paper-dim);
   line-height: 1.6;
   margin: 18px 0 26px;
   max-width: 52ch;
   font-size: 15.5px;
 }
-.flagship__body code {
+.page--home .flagship__body code {
   color: var(--signal-2);
   background: rgba(255,90,31,0.07);
   padding: 1px 5px;
@@ -639,25 +674,25 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
   font-size: .9em;
   font-family: var(--mono);
 }
-.flagship__body em.serif { color: var(--paper); }
+.page--home .flagship__body em.serif { color: var(--paper); }
 
-.flagship__demo { margin: 8px 0 28px; }
+.page--home .flagship__demo { margin: 8px 0 28px; }
 
-.flagship__foot {
+.page--home .flagship__foot {
   display: flex; flex-wrap: wrap; gap: 12px; align-items: center;
   padding-top: 22px;
   border-top: 1px dashed var(--rule);
 }
 
-.flagship__card--kubefwd { background: var(--ink-2); }
-.flagship__card--txeh {
+.page--home .flagship__card--kubefwd { background: var(--ink-2); }
+.page--home .flagship__card--txeh {
   background:
     linear-gradient(135deg, rgba(255,90,31,0.025), transparent 60%),
     var(--ink-2);
 }
 
-/* Terminal */
-.terminal {
+/* Terminal (homepage demo block; .terminal is a common name so scope it) */
+.page--home .terminal {
   background: #0A0A07;
   border: 1px solid var(--rule);
   border-radius: 4px;
@@ -665,21 +700,21 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
   font-family: var(--mono);
   box-shadow: 0 12px 36px rgba(0,0,0,0.4), inset 0 0 0 1px rgba(255,255,255,0.02);
 }
-.terminal__bar {
+.page--home .terminal__bar {
   display: flex; align-items: center; gap: 8px;
   padding: 9px 14px;
   background: linear-gradient(180deg, #161410, #0E0D0A);
   border-bottom: 1px solid var(--rule);
   position: relative;
 }
-.terminal__bar span {
+.page--home .terminal__bar span {
   width: 10px; height: 10px; border-radius: 50%;
   background: #2A2A22;
 }
-.terminal__bar span:nth-child(1) { background: #FF5F56; }
-.terminal__bar span:nth-child(2) { background: #FFBD2E; }
-.terminal__bar span:nth-child(3) { background: #27C93F; }
-.terminal__bar em {
+.page--home .terminal__bar span:nth-child(1) { background: #FF5F56; }
+.page--home .terminal__bar span:nth-child(2) { background: #FFBD2E; }
+.page--home .terminal__bar span:nth-child(3) { background: #27C93F; }
+.page--home .terminal__bar em {
   position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%);
   font-style: normal;
   font-size: 11px;
@@ -687,7 +722,7 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
   letter-spacing: 0.04em;
   font-family: var(--mono);
 }
-.terminal__body {
+.page--home .terminal__body {
   padding: 18px 18px;
   font-size: 12.5px;
   line-height: 1.7;
@@ -697,21 +732,21 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
   margin: 0;
   background: transparent;
 }
-.t-prompt { color: var(--signal); margin-right: 8px; }
-.t-ok     { color: var(--acid); }
-.t-mute   { color: var(--mute); }
+.page--home .t-prompt { color: var(--signal); margin-right: 8px; }
+.page--home .t-ok     { color: var(--acid); }
+.page--home .t-mute   { color: var(--mute); }
 
 /* ──────────────────────────────────────────────────────────────
    STACK LIST (features list, hover-shifts)
    ────────────────────────────────────────────────────────────── */
 
-.stack {
+.page--home .stack {
   list-style: none;
   border-top: 1px solid var(--rule);
   margin: 0;
   padding: 0;
 }
-.stack__row {
+.page--home .stack__row {
   display: grid;
   grid-template-columns: 80px 1fr 130px 40px;
   align-items: center;
@@ -721,20 +756,20 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
   transition: background .25s, padding .25s;
   cursor: default;
 }
-.stack__row:hover {
+.page--home .stack__row:hover {
   background: var(--ink-2);
   padding-left: 22px;
   padding-right: 22px;
 }
-.stack__row:hover .stack__name { color: var(--signal); }
-.stack__row:hover .stack__year { color: var(--signal); transform: translateX(4px); }
-.stack__num {
+.page--home .stack__row:hover .stack__name { color: var(--signal); }
+.page--home .stack__row:hover .stack__year { color: var(--signal); transform: translateX(4px); }
+.page--home .stack__num {
   font-family: var(--mono);
   color: var(--mute-2);
   font-size: 13px;
   letter-spacing: 0.08em;
 }
-.stack__name {
+.page--home .stack__name {
   display: block;
   font-family: var(--serif);
   font-style: italic;
@@ -746,13 +781,13 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
   margin-bottom: 6px;
   text-decoration: none;
 }
-.stack__desc {
+.page--home .stack__desc {
   color: var(--paper-dim);
   font-size: 14.5px;
   max-width: 70ch;
   line-height: 1.5;
 }
-.stack__desc code {
+.page--home .stack__desc code {
   font-family: var(--mono);
   font-size: 0.9em;
   color: var(--signal-2);
@@ -760,7 +795,7 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
   border-radius: 2px;
   padding: 1px 5px;
 }
-.stack__tag {
+.page--home .stack__tag {
   font-family: var(--mono);
   font-size: 11px;
   text-transform: uppercase;
@@ -773,14 +808,14 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
   background: rgba(0,0,0,0.2);
   justify-self: end;
 }
-.stack__year {
+.page--home .stack__year {
   font-family: var(--mono);
   color: var(--mute);
   text-align: right;
   transition: transform .25s, color .25s;
   font-size: 18px;
 }
-.stack__row--more .stack__name {
+.page--home .stack__row--more .stack__name {
   font-style: normal;
   font-family: var(--sans);
   font-size: 18px;
@@ -788,23 +823,23 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
 }
 
 @media (max-width: 760px) {
-  .stack__row { grid-template-columns: 50px 1fr 50px; }
-  .stack__tag { display: none; }
+  .page--home .stack__row { grid-template-columns: 50px 1fr 50px; }
+  .page--home .stack__tag { display: none; }
 }
 
 /* ──────────────────────────────────────────────────────────────
    CODA
    ────────────────────────────────────────────────────────────── */
 
-.section--coda { padding-top: 80px; padding-bottom: 140px; }
-.coda {
+.page--home .section--coda { padding-top: 80px; padding-bottom: 140px; }
+.page--home .coda {
   max-width: 1000px;
   margin: 0 auto;
   text-align: left;
   border-left: 1px solid var(--signal);
   padding-left: clamp(28px, 5vw, 60px);
 }
-.coda__kicker {
+.page--home .coda__kicker {
   font-family: var(--mono);
   font-size: 11px;
   text-transform: uppercase;
@@ -812,7 +847,7 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
   color: var(--mute);
   margin-bottom: 24px;
 }
-.coda__big {
+.page--home .coda__big {
   font-family: var(--serif);
   font-weight: 300;
   font-size: clamp(28px, 3.6vw, 52px);
@@ -822,9 +857,9 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
   font-variation-settings: "opsz" 144;
   margin-bottom: 48px;
 }
-.coda__big a { color: inherit; }
-.coda__big em.serif { color: var(--signal); }
-.coda__cta {
+.page--home .coda__big a { color: inherit; }
+.page--home .coda__big em.serif { color: var(--signal); }
+.page--home .coda__cta {
   display: flex; align-items: center; gap: 16px; flex-wrap: wrap;
   padding-top: 28px;
   border-top: 1px dashed var(--rule);
@@ -882,10 +917,13 @@ a.btn:focus-visible { outline-offset: 4px; }
 
 /* ──────────────────────────────────────────────────────────────
    HOMEPAGE FOOTER
+   Renamed from .footer to .home-footer to avoid collision with
+   any markdown that uses class="footer". The dead adjacent-sibling
+   selector .page--home + .footer never matched because Material
+   wraps both in .md-container.
    ────────────────────────────────────────────────────────────── */
 
-.page--home + .footer,
-.footer {
+.home-footer {
   position: relative;
   z-index: 1;
   background: var(--ink);
@@ -893,28 +931,28 @@ a.btn:focus-visible { outline-offset: 4px; }
   padding: 60px var(--gutter) 28px;
   margin-top: 60px;
 }
-.footer__rule {
+.home-footer__rule {
   height: 1px;
   background: linear-gradient(90deg, transparent, var(--rule-2), transparent);
   margin-bottom: 50px;
 }
-.footer__inner {
+.home-footer__inner {
   display: grid;
   grid-template-columns: 1.5fr 1fr 1fr 1fr 1.1fr;
   gap: 32px;
   margin-bottom: 60px;
 }
 @media (max-width: 1180px) {
-  .footer__inner { grid-template-columns: 1fr 1fr 1fr; }
+  .home-footer__inner { grid-template-columns: 1fr 1fr 1fr; }
 }
 @media (max-width: 720px) {
-  .footer__inner { grid-template-columns: 1fr 1fr; }
+  .home-footer__inner { grid-template-columns: 1fr 1fr; }
 }
 @media (max-width: 480px) {
-  .footer__inner { grid-template-columns: 1fr; gap: 28px; }
+  .home-footer__inner { grid-template-columns: 1fr; gap: 28px; }
 }
-.footer__col { min-width: 0; }
-.footer__label {
+.home-footer__col { min-width: 0; }
+.home-footer__label {
   font-family: var(--mono);
   font-size: 11px;
   color: var(--signal);
@@ -924,51 +962,51 @@ a.btn:focus-visible { outline-offset: 4px; }
   padding-bottom: 10px;
   border-bottom: 1px solid var(--rule);
 }
-.footer__text {
+.home-footer__text {
   color: var(--paper-dim);
   font-size: 14px;
   line-height: 1.55;
   max-width: 50ch;
   margin: 0;
 }
-.footer__text a {
+.home-footer__text a {
   color: var(--paper);
   border-bottom: 1px solid var(--rule-2);
   text-decoration: none;
   transition: color .2s, border-color .2s;
 }
-.footer__text a:hover { color: var(--signal); border-color: var(--signal); }
-.footer__links {
+.home-footer__text a:hover { color: var(--signal); border-color: var(--signal); }
+.home-footer__links {
   list-style: none;
   font-family: var(--mono);
   font-size: 13px;
   margin: 0;
   padding: 0;
 }
-.footer__links li { padding: 4px 0; }
-.footer__links a {
+.home-footer__links li { padding: 4px 0; }
+.home-footer__links a {
   color: var(--paper-dim);
   text-decoration: none;
   transition: color .2s;
 }
-.footer__links a:hover { color: var(--signal); }
-.footer__links__sub {
+.home-footer__links a:hover { color: var(--signal); }
+.home-footer__links__sub {
   color: var(--mute);
   font-style: italic;
   font-family: var(--serif);
   font-size: 12.5px;
   margin-left: 4px;
 }
-.footer__col--meta .footer__mono {
+.home-footer__col--meta .home-footer__mono {
   font-family: var(--mono);
   font-size: 12px;
   color: var(--mute);
   line-height: 1.7;
   margin: 0;
 }
-.footer__col--meta .dot { color: var(--rule-2); margin: 0 4px; }
+.home-footer__col--meta .dot { color: var(--rule-2); margin: 0 4px; }
 
-.footer__base {
+.home-footer__base {
   display: flex; justify-content: space-between; align-items: center;
   flex-wrap: wrap; gap: 14px;
   padding-top: 24px;
@@ -978,8 +1016,8 @@ a.btn:focus-visible { outline-offset: 4px; }
   color: var(--mute);
   letter-spacing: 0.04em;
 }
-.footer__base p { margin: 0; }
-.footer__base__tag { color: var(--signal); }
+.home-footer__base p { margin: 0; }
+.home-footer__base__tag { color: var(--signal); }
 
 /* ──────────────────────────────────────────────────────────────
    INNER PAGES / Material chrome restyle
@@ -1178,7 +1216,8 @@ a.md-header__button.md-logo:hover ~ .md-header__title .md-header__topic,
 }
 
 /* Any heading containing inline code switches to mono entirely so the
-   technical reference reads as code, not as italic display text. */
+   technical reference reads as code, not as italic display text.
+   :has() is supported in Firefox 121+ (Dec 2023) and Safari 15.4+. */
 .md-typeset h1:has(code),
 .md-typeset h2:has(code),
 .md-typeset h3:has(code),
@@ -1201,6 +1240,45 @@ a.md-header__button.md-logo:hover ~ .md-header__title .md-header__topic,
   color: var(--signal);
   font-size: 1em;
 }
+
+/* Fallback for browsers without :has() support: code inside any heading
+   gets the mono+signal treatment even if the heading itself stays in
+   Fraunces. Less ideal but still readable. */
+@supports not selector(:has(*)) {
+  .md-typeset h1 code,
+  .md-typeset h2 code,
+  .md-typeset h3 code,
+  .md-typeset h4 code {
+    background: transparent;
+    border: 0;
+    padding: 0;
+    color: var(--signal);
+    font-family: var(--mono);
+    font-weight: 700;
+    font-style: normal;
+    font-size: 0.92em;
+  }
+}
+
+/* Mermaid: container + a couple of element-level overrides for things
+   Material's variables don't fully cover. */
+.md-typeset .mermaid {
+  background: var(--ink-3);
+  border: 1px dashed var(--rule);
+  border-radius: 2px;
+  padding: 18px 20px;
+  margin: 1.4em 0;
+  font-family: var(--mono);
+  text-align: center;
+  overflow-x: auto;
+}
+.md-typeset .mermaid svg { max-width: 100%; height: auto; display: inline-block; }
+.md-typeset .mermaid .edgeLabel {
+  background: var(--ink-3) !important;
+  color: var(--paper-dim) !important;
+  padding: 2px 6px !important;
+}
+.md-typeset .mermaid .cluster rect { fill: var(--ink-2) !important; stroke: var(--rule) !important; }
 
 /* Heading anchor link */
 .md-typeset .headerlink {


### PR DESCRIPTION
Follow-up to #473. Two commits.

## Summary

### `132e0bf` — Address PR #473 review findings

Post-merge code review surfaced six issues. All addressed.

- **Component class-name leakage.** Every homepage component class (`.hero__*`, `.section`, `.section__*`, `.flagship*`, `.terminal*`, `.stack*`, `.coda*`, `.ticker*`, `.dropcap`, `.outline`) now requires `.page--home` as an ancestor selector. Without scoping, any inner-page markdown using `class="terminal"` or `class="section"` would inherit homepage display styling.
- **Footer collision.** Renamed `.footer` (and all `__rule`, `__inner`, `__col`, `__label`, `__text`, `__links`, `__mono`, `__base` siblings) to `.home-footer`. Dropped the dead `.page--home + .footer` adjacent-sibling selector that never matched in the actual DOM nesting.
- **Overlay z-index.** Lowered `body::before` (grain) and `body::after` (vignette) from `z-index: 100` to `z-index: 1` so the rail (z 50) and skiplink (z 200) are no longer darkened by the vignette.
- **`:has()` fallback.** Added `@supports not selector(:has(*))` block so headings containing inline code still render with mono+signal on Firefox <121 and Safari <15.4 (less ideal, but readable).
- **`setInterval` leak under `navigation.instant`.** Wrapped the live UTC clock IIFE with `window.__kubefwdClock` global guard. Each return to the homepage via instant-nav now reuses the existing handle and refreshes the displayed time without registering a new interval.
- **Mermaid theme.** Added Material's `--md-mermaid-*` CSS variables to the slate scheme block and a `.md-typeset .mermaid` container restyle. Architecture and MCP integration diagrams now render with the txn2 dark palette.

### `4a14b8f` — Add local DESIGN.md adoption record

Thin local sidecar to canonical [`txn2/www/DESIGN.md`](https://github.com/txn2/www/blob/master/DESIGN.md) and `tokens.json`. References upstream as the source of truth for tokens, typography, components, and voice. Records only what is project-specific and the MkDocs Material learnings that do not apply to the upstream Hugo site.

Sections:

- **What is canonical** — table mapping every concern (palette, type scale, components, voice, mermaid) to upstream
- **Adoption level** — explicit \"token alignment\" per upstream's downstream contract
- **File map** — what each touched file owns
- **Project-specific components** — what is used, what is NOT used (with reason), kubefwd-only additions
- **MkDocs Material learnings** — 12 numbered, named lessons covering: custom homepage template, Material variable overrides, `font: false`, scoping discipline, footer rename, technical h3/h4 typography, tabbed-set restyle, Mermaid via CSS vars, `setInterval` guard, dark-only palette, overlay z-index, what Hugo can do that MkDocs cannot
- **Voice and copy** — defers to upstream
- **Updating** — workflow for when upstream changes
- **Downstream contract for sister projects** — instructions for txeh, mcp-s3, mcp-trino, mcp-datahub, mcp-data-platform to use this file as a template

## Files

| Path | Change |
|------|--------|
| \`DESIGN.md\` | new, 243 lines |
| \`docs/overrides/home.html\` | footer class rename, clock IIFE guard |
| \`docs/stylesheets/extra.css\` | scoping, footer rename, z-index, :has fallback, mermaid vars |

## Test plan

- [ ] \`mkdocs build --strict\` passes
- [ ] Homepage renders the same as before the scoping changes (no visual regression)
- [ ] Inner pages with markdown that happens to use \`class=\"terminal\"\` or \`class=\"section\"\` no longer inherit homepage styling
- [ ] Vignette no longer darkens the rail
- [ ] Live UTC clock keeps ticking after several instant-nav round trips back to homepage; only one interval handle in DevTools timers
- [ ] \`/architecture/\` Mermaid diagrams render with dark palette (paper text, ink-3 nodes, mute edges)
- [ ] \`grep -RE \"—|–\" docs/ DESIGN.md mkdocs.yml\` returns nothing
- [ ] \`DESIGN.md\` is discoverable at the repo root, alongside README and CLAUDE.md