### PR TITLE
docs: graphite re-skin (type, color, chrome)

### DIFF
--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -23,8 +23,6 @@
   <div class="rail__meta">
     <span class="rail__rel">v1.x</span>
     <span class="rail__dot" aria-hidden="true">●</span>
-    <span data-clock>·· UTC</span>
-    <span class="rail__dot" aria-hidden="true">●</span>
     <a href="https://txn2.com" class="rail__org">part of <em class="serif">txn2</em>&nbsp;↗</a>
   </div>
   <nav class="rail__nav" aria-label="primary">
@@ -70,7 +68,6 @@
     <h1 class="hero__display">
       <span class="hero__row hero__row--1">
         <em class="serif">kubefwd</em>
-        <span class="hero__chip">v1.x · go</span>
       </span>
       <span class="hero__row hero__row--2">
         <span class="outline">kubernetes</span>
@@ -82,7 +79,7 @@
 
     <div class="hero__intro">
       <p class="hero__lede">
-        <span class="dropcap">k</span>ubefwd port-forwards Kubernetes services in bulk: a single service, a whole namespace, several namespaces at once, or several clusters at once, optionally filtered by label or field selector. Each service it touches gets its own <strong>127.x.x.x</strong> loopback address with the cluster hostname written to <code>/etc/hosts</code>. In-cluster connection strings (<code>http://api:8080</code>, <code>redis-cli -h cache</code>, <code>mysql -h db</code>) resolve and work without modification. Multiple databases on port 3306, multiple gateways on 443. No conflicts, no remapping, no environment-specific config.
+        kubefwd port-forwards Kubernetes services in bulk: a single service, a whole namespace, several namespaces at once, or several clusters at once, optionally filtered by label or field selector. Each service it touches gets its own <strong>127.x.x.x</strong> loopback address with the cluster hostname written to <code>/etc/hosts</code>. In-cluster connection strings (<code>http://api:8080</code>, <code>redis-cli -h cache</code>, <code>mysql -h db</code>) resolve and work without modification. Multiple databases on port 3306, multiple gateways on 443. No conflicts, no remapping, no environment-specific config.
       </p>
       <p class="hero__lede hero__lede--muted">
         Watches Kubernetes events and reconnects automatically on pod churn. Handles headless services with one address per pod, port remapping, custom domain suffixes, and IP reservation. Drive it from an interactive TUI with live traffic and log streaming, a 40+ endpoint REST API, or an MCP server for AI assistants. Apache 2.0, on the <a href="https://landscape.cncf.io/?item=app-definition-and-development--application-definition-image-build--kubefwd">CNCF Landscape</a> since 2018.
@@ -215,71 +212,57 @@
       </p>
     </header>
 
-    <ol class="stack">
+    <ul class="stack">
       <li class="stack__row">
-        <span class="stack__num">001</span>
         <div class="stack__main">
           <a class="stack__name" href="architecture/#ip-allocation">unique loopback ip per service</a>
           <p class="stack__desc">Each service gets its own <code>127.x.x.x</code> address. Many databases on port 3306, many web services on port 80. No conflicts, no remapping. The local network mirrors the cluster network.</p>
         </div>
-        <span class="stack__tag">network</span>
         <span class="stack__year" aria-hidden="true">↗</span>
       </li>
       <li class="stack__row">
-        <span class="stack__num">002</span>
         <div class="stack__main">
           <a class="stack__name" href="advanced-usage/#custom-hosts-file-path">/etc/hosts integration</a>
           <p class="stack__desc">Service names resolve to the assigned loopback IPs through the host file. Any application, any language, no configuration to teach. Backup of the original hosts file is kept at <code>~/hosts.original</code>.</p>
         </div>
-        <span class="stack__tag">dns / hosts</span>
         <span class="stack__year" aria-hidden="true">↗</span>
       </li>
       <li class="stack__row">
-        <span class="stack__num">003</span>
         <div class="stack__main">
           <a class="stack__name" href="user-guide/#auto-reconnect">auto-reconnect with backoff</a>
           <p class="stack__desc">Pods restart, kubefwd re-establishes the forward. Exponential backoff from 1s to 5min ceiling. Watch events keep the local state aligned with cluster reality during rolling deploys.</p>
         </div>
-        <span class="stack__tag">runtime</span>
         <span class="stack__year" aria-hidden="true">↗</span>
       </li>
       <li class="stack__row">
-        <span class="stack__num">004</span>
         <div class="stack__main">
           <a class="stack__name" href="user-guide/#interface-overview">interactive tui</a>
           <p class="stack__desc">Bubble Tea TUI with live bandwidth sparklines, pod log streaming, and HTTP request detection. Filter, navigate, reconnect, all from the keyboard. Full help overlay on <code>?</code>.</p>
         </div>
-        <span class="stack__tag">tui</span>
         <span class="stack__year" aria-hidden="true">↗</span>
       </li>
       <li class="stack__row">
-        <span class="stack__num">005</span>
         <div class="stack__main">
           <a class="stack__name" href="api-reference/">rest api · 40+ endpoints</a>
           <p class="stack__desc">Add namespaces, register services, query metrics, stream SSE events. Drives editors, CI tooling, and any process that wants to script local cluster access.</p>
         </div>
-        <span class="stack__tag">api</span>
         <span class="stack__year" aria-hidden="true">↗</span>
       </li>
       <li class="stack__row">
-        <span class="stack__num">006</span>
         <div class="stack__main">
           <a class="stack__name" href="mcp-integration/">mcp server for ai clients</a>
           <p class="stack__desc">Drop-in MCP server. Claude, Cursor, and any MCP-capable assistant can connect, browse cluster services, and forward what your task needs. Talk about the work, not the tooling.</p>
         </div>
-        <span class="stack__tag">mcp</span>
         <span class="stack__year" aria-hidden="true">↗</span>
       </li>
       <li class="stack__row stack__row--more">
-        <span class="stack__num">···</span>
         <div class="stack__main">
           <a class="stack__name" href="advanced-usage/">multi-namespace, multi-cluster, port mapping, label selectors, headless services, ip reservation</a>
           <p class="stack__desc">Full feature surface in advanced usage.</p>
         </div>
-        <span class="stack__tag">+ more</span>
         <span class="stack__year" aria-hidden="true">↗</span>
       </li>
-    </ol>
+    </ul>
   </section>
 
   {# CODA / sister projects, context #}
@@ -343,7 +326,7 @@
       <p class="home-footer__label">txn2 / org</p>
       <p class="home-footer__text"><a href="https://txn2.com">txn2.com&nbsp;↗</a><br>
       <span class="home-footer__links__sub">canonical home of the txn2 open source organization</span></p>
-      <p class="home-footer__mono">apache 2.0 license <span class="dot">·</span> <span data-clock>·· UTC</span></p>
+      <p class="home-footer__mono">apache 2.0 license</p>
     </div>
   </div>
   <div class="home-footer__base">
@@ -351,32 +334,4 @@
     <p class="home-footer__base__tag"><a href="https://txn2.com">design · txn2.com&nbsp;↗</a></p>
   </div>
 </footer>
-{% endblock %}
-
-{% block scripts %}
-{{ super() }}
-<script>
-  // Live UTC clock for rail/footer.
-  // Guarded against duplicate registration: Material's instant-nav rehydrates
-  // the body on every navigation back to the homepage; without this guard a
-  // fresh setInterval handle leaks each visit.
-  (function () {
-    if (window.__kubefwdClock) {
-      window.__kubefwdClock.tick();
-      return;
-    }
-    function tick() {
-      var now = new Date();
-      var hh = String(now.getUTCHours()).padStart(2, '0');
-      var mm = String(now.getUTCMinutes()).padStart(2, '0');
-      var stamp = hh + ':' + mm + ' UTC';
-      document.querySelectorAll('[data-clock]').forEach(function (el) {
-        el.textContent = stamp;
-      });
-    }
-    tick();
-    var handle = setInterval(tick, 30 * 1000);
-    window.__kubefwdClock = { tick: tick, handle: handle };
-  })();
-</script>
 {% endblock %}

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -3,7 +3,7 @@
 {% block extrahead %}
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..700;1,9..144,300..700&family=Instrument+Sans:wght@400..700&family=JetBrains+Mono:wght@400..700&display=swap">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500;600&display=swap">
 
   <meta property="og:type" content="website">
   <meta property="og:url" content="{{ config.site_url }}">

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -5,25 +5,31 @@
    ─────────────────────────────────────────────────────────────── */
 
 :root {
-  --ink:        #0B0B09;
-  --ink-2:      #131310;
-  --ink-3:      #1B1A15;
-  --rule:       #2A2922;
-  --rule-2:     #3A3830;
+  /* Graphite grey ground — lifted off near-black so it reads as grey, not black. */
+  --ink:        #1E232A;
+  --ink-2:      #262C34;
+  --ink-3:      #2F3640;
+  --rule:       #3A424C;
+  --rule-2:     #47515C;
 
-  --paper:      #ECE3CE;
-  --paper-dim:  #C9C0AB;
-  --mute:       #968F80;
-  --mute-2:     #5A554B;
+  /* Cool light foreground — replaces the cream "paper". */
+  --paper:      #EDF1F5;
+  --paper-dim:  #C4CCD4;
+  --mute:       #8A95A0;
+  --mute-2:     #5C6670;
 
-  --signal:     #FF5A1F;
-  --signal-2:   #FF8A4C;
-  --acid:       #E1FF6E;
-  --cool:       #6FE1FF;
+  /* Single restrained accent (cyan) + code-syntax hues. */
+  --signal:     #4FC7E6;
+  --signal-2:   #7FD6EC;
+  --acid:       #9BCB86;
+  --cool:       #8FB6D6;
 
-  --serif:      "Fraunces", "Times New Roman", serif;
-  --sans:       "Instrument Sans", -apple-system, "Helvetica Neue", sans-serif;
-  --mono:       "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
+  /* --serif carries the DISPLAY face used for headings. The direction
+     moved off serif to a technical mono; the token name is kept so the
+     shared txn2 design system stays parity-mapped across sister repos. */
+  --serif:      "Geist Mono", ui-monospace, "SF Mono", Menlo, monospace;
+  --sans:       "Geist", -apple-system, "Helvetica Neue", sans-serif;
+  --mono:       "Geist Mono", ui-monospace, "SF Mono", Menlo, monospace;
 
   --measure:    64ch;
   --rail-h:     56px;
@@ -53,21 +59,21 @@
   --md-primary-bg-color--light:    var(--paper-dim);
 
   --md-accent-fg-color:            var(--signal);
-  --md-accent-fg-color--transparent: rgba(255,90,31,0.10);
+  --md-accent-fg-color--transparent: rgba(79,199,230,0.10);
   --md-accent-bg-color:            var(--ink);
   --md-accent-bg-color--light:     var(--ink-2);
 
   --md-typeset-color:              var(--paper);
   --md-typeset-a-color:            var(--signal);
-  --md-typeset-mark-color:         rgba(255,90,31,0.25);
+  --md-typeset-mark-color:         rgba(79,199,230,0.25);
   --md-typeset-kbd-color:          var(--ink-3);
   --md-typeset-kbd-accent-color:   var(--rule-2);
   --md-typeset-kbd-border-color:   var(--rule);
 
   --md-code-bg-color:              var(--ink-2);
   --md-code-fg-color:              var(--paper);
-  --md-code-hl-color:              rgba(255,90,31,0.15);
-  --md-code-hl-color--light:       rgba(255,90,31,0.08);
+  --md-code-hl-color:              rgba(79,199,230,0.15);
+  --md-code-hl-color--light:       rgba(79,199,230,0.08);
   --md-code-hl-name-color:         var(--paper);
   --md-code-hl-keyword-color:      var(--signal);
   --md-code-hl-string-color:       var(--acid);
@@ -115,9 +121,13 @@
   --md-mermaid-sequence-loop-border-color:  var(--rule-2);
   --md-mermaid-sequence-message-fg-color:   var(--paper-dim);
   --md-mermaid-sequence-message-line-color: var(--mute);
-  --md-mermaid-sequence-note-bg-color:      var(--ink-2);
+  /* Soft filled label, not a hard-bordered box: mermaid under-sizes note
+     rects (text can exceed the rect by ~20px), and a crisp cyan border makes
+     that overflow read as broken. Border matches the fill so there is no hard
+     edge for text to cross. */
+  --md-mermaid-sequence-note-bg-color:      var(--ink-3);
   --md-mermaid-sequence-note-fg-color:      var(--paper);
-  --md-mermaid-sequence-note-border-color:  var(--signal);
+  --md-mermaid-sequence-note-border-color:  var(--ink-3);
   --md-mermaid-sequence-number-bg-color:    var(--signal);
   --md-mermaid-sequence-number-fg-color:    var(--ink);
 }
@@ -153,7 +163,7 @@ body {
 
 img { max-width: 100%; display: block; }
 
-em.serif { font-family: var(--serif); font-style: italic; font-weight: 400; }
+em.serif { font-family: var(--serif); font-style: normal; font-weight: 500; }
 
 /* Skip-to-content link */
 .skiplink {
@@ -202,15 +212,13 @@ body::before {
   background-image: url("data:image/svg+xml;utf8,<svg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='3' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 1 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
 }
 body::after {
-  background: radial-gradient(ellipse at center, transparent 50%, rgba(0,0,0,0.45) 100%);
+  background: radial-gradient(ellipse at center, transparent 65%, rgba(0,0,0,0.14) 100%);
 }
 
-/* Subtle warm tint behind the canvas, like the reference. */
+/* Flat cool gradient behind the canvas — no colored glow. */
 .md-container,
 .page--home {
   background-image:
-    radial-gradient(circle at 18% 6%, rgba(255,90,31,0.05), transparent 38%),
-    radial-gradient(circle at 92% 84%, rgba(225,255,110,0.025), transparent 42%),
     linear-gradient(180deg, var(--ink) 0%, var(--ink-2) 100%);
 }
 
@@ -237,8 +245,8 @@ body::after {
 .blueprint__grid {
   position: absolute; inset: 0;
   background-image:
-    linear-gradient(to right, rgba(236,227,206,0.04) 1px, transparent 1px),
-    linear-gradient(to bottom, rgba(236,227,206,0.04) 1px, transparent 1px);
+    linear-gradient(to right, rgba(199,204,212,0.04) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(199,204,212,0.04) 1px, transparent 1px);
   background-size: 64px 64px;
   -webkit-mask-image: linear-gradient(180deg, transparent, black 12%, black 88%, transparent);
           mask-image: linear-gradient(180deg, transparent, black 12%, black 88%, transparent);
@@ -266,7 +274,7 @@ header.rail {
   align-items: center;
   gap: 24px;
   padding: 14px var(--gutter);
-  background: rgba(11,11,9,0.72);
+  background: rgba(13,15,18,0.72);
   backdrop-filter: blur(14px) saturate(140%);
   -webkit-backdrop-filter: blur(14px) saturate(140%);
   border-bottom: 1px solid var(--rule);
@@ -297,13 +305,13 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
   animation: spin 24s linear infinite;
 }
 .rail__name {
-  font-family: var(--serif);
-  font-style: italic;
-  font-size: 22px;
+  font-family: var(--mono);
+  font-style: normal;
+  font-size: 15px;
   text-transform: lowercase;
   letter-spacing: -0.01em;
   color: var(--paper);
-  font-weight: 400;
+  font-weight: 600;
 }
 .rail__sep { color: var(--rule-2); }
 .rail__sub { color: var(--mute); }
@@ -327,7 +335,7 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
 }
 .rail__org em.serif {
   color: var(--paper);
-  font-style: italic;
+  font-style: normal;
   font-family: var(--serif);
 }
 .rail__org:hover { color: var(--signal); border-bottom-color: var(--signal); }
@@ -361,7 +369,7 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
 @media (max-width: 540px) {
   header.rail { padding: 12px 16px; gap: 10px; }
   .rail__brand { gap: 6px; min-width: 0; }
-  .rail__name { font-size: 18px; }
+  .rail__name { font-size: 14px; }
   .rail__mark { font-size: 16px; }
   .rail__nav { gap: 12px; font-size: 11px; }
   .rail__cta { padding: 5px 8px; }
@@ -401,19 +409,27 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
 .page--home .hero__stamp__line--ok { color: var(--signal); }
 
 .page--home .hero__display {
+  /* Hug the title to its own width (do not grow to fill the row) so the
+     absolutely-positioned, right-pinned hero__stamp keeps a clear gutter
+     instead of colliding with the display type on wide screens. */
+  flex: 0 1 auto;
+  min-width: 0;
   font-family: var(--serif);
-  font-weight: 300;
-  font-size: clamp(60px, 12.5vw, 220px);
-  line-height: 0.92;
-  letter-spacing: -0.04em;
-  margin-bottom: 56px;
-  font-variation-settings: "opsz" 144;
+  font-weight: 500;
+  /* Mono display runs ~1.5x wider than the former optical serif; cap the
+     ceiling well below the old ceiling so all three rows clear the stamp. */
+  font-size: clamp(24px, 3.4vw, 52px);
+  line-height: 1.02;
+  letter-spacing: -0.02em;
+  margin: 0;
 }
 .page--home .hero__row {
   display: flex; align-items: baseline; gap: clamp(12px, 2vw, 36px);
   flex-wrap: wrap;
 }
 .page--home .hero__row--1 { animation: rise 1.1s .25s both ease-out; }
+.page--home .hero__row--1 em.serif,
+.page--home .hero__row--3 em.serif { white-space: nowrap; }
 .page--home .hero__row--2 {
   padding-left: clamp(40px, 14vw, 240px);
   animation: rise 1.1s .4s both ease-out;
@@ -423,9 +439,8 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
   animation: rise 1.1s .55s both ease-out;
 }
 .page--home .hero__row em.serif {
-  font-style: italic;
+  font-style: normal;
   color: var(--paper);
-  font-variation-settings: "opsz" 144;
 }
 .page--home .outline {
   -webkit-text-stroke: 1.5px var(--paper);
@@ -433,20 +448,6 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
   font-style: normal;
   font-weight: 400;
   font-family: var(--serif);
-}
-.page--home .hero__chip {
-  font-family: var(--mono);
-  font-size: 13px;
-  letter-spacing: 0.04em;
-  color: var(--mute);
-  background: var(--ink-3);
-  border: 1px solid var(--rule);
-  padding: 6px 12px;
-  border-radius: 2px;
-  text-transform: uppercase;
-  align-self: center;
-  transform: translateY(-12px);
-  white-space: nowrap;
 }
 
 .page--home .hero__intro {
@@ -473,23 +474,12 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
   font-family: var(--mono);
   font-size: 0.9em;
   color: var(--signal-2);
-  background: rgba(255,90,31,0.08);
+  background: rgba(79,199,230,0.08);
   border-radius: 2px;
   padding: 1px 5px;
 }
 .page--home .hero__lede--muted { color: var(--mute); }
 
-.page--home .dropcap {
-  font-family: var(--serif);
-  font-style: italic;
-  font-size: 3.4em;
-  line-height: 0.85;
-  float: left;
-  padding: 6px 10px 0 0;
-  color: var(--signal);
-  font-weight: 400;
-  font-variation-settings: "opsz" 144;
-}
 
 @media (max-width: 760px) {
   .page--home .hero__stamp {
@@ -501,7 +491,6 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
   }
   .page--home .hero__intro { grid-template-columns: 1fr; padding-left: 0; }
   .page--home .hero__row--2, .page--home .hero__row--3 { padding-left: 0; }
-  .page--home .hero__chip { display: none; }
 }
 
 /* Ticker */
@@ -561,15 +550,14 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
 }
 .page--home .section__title {
   font-family: var(--serif);
-  font-weight: 300;
-  font-size: clamp(36px, 5.5vw, 76px);
-  line-height: 1.0;
-  letter-spacing: -0.025em;
+  font-weight: 600;
+  font-size: clamp(28px, 3.8vw, 52px);
+  line-height: 1.08;
+  letter-spacing: -0.02em;
   color: var(--paper);
-  font-variation-settings: "opsz" 144;
   margin-bottom: 24px;
 }
-.page--home .section__title em.serif { color: var(--signal); font-style: italic; }
+.page--home .section__title em.serif { color: var(--signal); font-style: normal; }
 .page--home .section__lede {
   color: var(--paper-dim);
   max-width: 64ch;
@@ -580,7 +568,7 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
   font-family: var(--mono);
   font-size: 0.9em;
   color: var(--signal-2);
-  background: rgba(255,90,31,0.08);
+  background: rgba(79,199,230,0.08);
   border-radius: 2px;
   padding: 1px 5px;
 }
@@ -636,13 +624,12 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
 .page--home .flagship__url:hover { color: var(--signal-2); border-bottom-color: var(--signal-2); }
 .page--home .flagship__name {
   font-family: var(--serif);
-  font-weight: 300;
-  font-style: italic;
-  font-size: clamp(48px, 5vw, 80px);
-  line-height: 0.95;
-  letter-spacing: -0.03em;
+  font-weight: 600;
+  font-style: normal;
+  font-size: clamp(30px, 3.4vw, 48px);
+  line-height: 1.0;
+  letter-spacing: -0.02em;
   color: var(--paper);
-  font-variation-settings: "opsz" 144;
   margin-bottom: 12px;
 }
 .page--home .flagship__tag {
@@ -655,7 +642,7 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
 .page--home .flagship__tag code {
   font-size: .92em;
   color: var(--signal);
-  background: rgba(255,90,31,0.08);
+  background: rgba(79,199,230,0.08);
   padding: 1px 6px;
   border-radius: 2px;
 }
@@ -668,7 +655,7 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
 }
 .page--home .flagship__body code {
   color: var(--signal-2);
-  background: rgba(255,90,31,0.07);
+  background: rgba(79,199,230,0.07);
   padding: 1px 5px;
   border-radius: 2px;
   font-size: .9em;
@@ -687,7 +674,7 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
 .page--home .flagship__card--kubefwd { background: var(--ink-2); }
 .page--home .flagship__card--txeh {
   background:
-    linear-gradient(135deg, rgba(255,90,31,0.025), transparent 60%),
+    linear-gradient(135deg, rgba(79,199,230,0.025), transparent 60%),
     var(--ink-2);
 }
 
@@ -748,7 +735,7 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
 }
 .page--home .stack__row {
   display: grid;
-  grid-template-columns: 80px 1fr 130px 40px;
+  grid-template-columns: 1fr auto;
   align-items: center;
   gap: 24px;
   padding: 24px 8px;
@@ -763,21 +750,15 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
 }
 .page--home .stack__row:hover .stack__name { color: var(--signal); }
 .page--home .stack__row:hover .stack__year { color: var(--signal); transform: translateX(4px); }
-.page--home .stack__num {
-  font-family: var(--mono);
-  color: var(--mute-2);
-  font-size: 13px;
-  letter-spacing: 0.08em;
-}
 .page--home .stack__name {
   display: block;
   font-family: var(--serif);
-  font-style: italic;
-  font-size: clamp(24px, 2.5vw, 34px);
+  font-style: normal;
+  font-weight: 600;
+  font-size: clamp(22px, 2.2vw, 30px);
   color: var(--paper);
-  line-height: 1.05;
+  line-height: 1.1;
   transition: color .25s;
-  font-variation-settings: "opsz" 144;
   margin-bottom: 6px;
   text-decoration: none;
 }
@@ -791,22 +772,9 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
   font-family: var(--mono);
   font-size: 0.9em;
   color: var(--signal-2);
-  background: rgba(255,90,31,0.08);
+  background: rgba(79,199,230,0.08);
   border-radius: 2px;
   padding: 1px 5px;
-}
-.page--home .stack__tag {
-  font-family: var(--mono);
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.18em;
-  color: var(--mute);
-  text-align: right;
-  border: 1px solid var(--rule);
-  padding: 5px 10px;
-  border-radius: 2px;
-  background: rgba(0,0,0,0.2);
-  justify-self: end;
 }
 .page--home .stack__year {
   font-family: var(--mono);
@@ -823,8 +791,7 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
 }
 
 @media (max-width: 760px) {
-  .page--home .stack__row { grid-template-columns: 50px 1fr 50px; }
-  .page--home .stack__tag { display: none; }
+  .page--home .stack__row { grid-template-columns: 1fr auto; }
 }
 
 /* ──────────────────────────────────────────────────────────────
@@ -849,13 +816,13 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
 }
 .page--home .coda__big {
   font-family: var(--serif);
-  font-weight: 300;
-  font-size: clamp(28px, 3.6vw, 52px);
-  line-height: 1.15;
-  letter-spacing: -0.02em;
+  font-weight: 500;
+  font-size: clamp(14px, 1.05vw, 16px);
+  line-height: 1.6;
+  letter-spacing: 0;
   color: var(--paper);
-  font-variation-settings: "opsz" 144;
-  margin-bottom: 48px;
+  margin-bottom: 28px;
+  max-width: 72ch;
 }
 .page--home .coda__big a { color: inherit; }
 .page--home .coda__big em.serif { color: var(--signal); }
@@ -992,8 +959,8 @@ a.btn:focus-visible { outline-offset: 4px; }
 .home-footer__links a:hover { color: var(--signal); }
 .home-footer__links__sub {
   color: var(--mute);
-  font-style: italic;
-  font-family: var(--serif);
+  font-style: normal;
+  font-family: var(--mono);
   font-size: 12.5px;
   margin-left: 4px;
 }
@@ -1027,7 +994,7 @@ a.btn:focus-visible { outline-offset: 4px; }
 
 /* Header (kept on inner pages, rail-styled) */
 .md-header {
-  background: rgba(11,11,9,0.86);
+  background: rgba(13,15,18,0.86);
   backdrop-filter: blur(14px) saturate(140%);
   -webkit-backdrop-filter: blur(14px) saturate(140%);
   border-bottom: 1px solid var(--rule);
@@ -1036,17 +1003,17 @@ a.btn:focus-visible { outline-offset: 4px; }
 }
 .md-header[data-md-state="shadow"] { box-shadow: none; }
 .md-header__title {
-  font-family: var(--serif);
-  font-style: italic;
-  font-weight: 300;
-  font-size: 22px;
+  font-family: var(--mono);
+  font-style: normal;
+  font-weight: 600;
+  font-size: 16px;
   letter-spacing: -0.01em;
   color: var(--paper);
 }
 .md-header__title .md-header__topic {
-  font-family: var(--serif);
-  font-style: italic;
-  font-weight: 300;
+  font-family: var(--mono);
+  font-style: normal;
+  font-weight: 600;
   color: var(--paper);
   transition: color .2s ease;
 }
@@ -1148,29 +1115,28 @@ a.md-header__button.md-logo:hover ~ .md-header__title .md-header__topic,
   color: var(--mute);
 }
 
-/* Inner-page typography (Fraunces headings, paper body) */
+/* Inner-page typography — headings in the technical mono display face,
+   body in the sans. Non-italic: the direction moved off the italic serif. */
 .md-content { background: transparent; color: var(--paper); }
 .md-typeset { color: var(--paper); font-family: var(--sans); }
 
 .md-typeset h1 {
   font-family: var(--serif);
-  font-weight: 300;
-  font-style: italic;
-  font-variation-settings: "opsz" 144;
-  font-size: clamp(36px, 4.4vw, 60px);
-  line-height: 1.0;
-  letter-spacing: -0.025em;
+  font-weight: 600;
+  font-style: normal;
+  font-size: clamp(30px, 4vw, 46px);
+  line-height: 1.05;
+  letter-spacing: -0.02em;
   color: var(--paper);
   margin: 0 0 0.6em;
 }
 .md-typeset h2 {
   font-family: var(--serif);
-  font-weight: 300;
-  font-style: italic;
-  font-variation-settings: "opsz" 144;
-  font-size: clamp(26px, 2.8vw, 38px);
-  line-height: 1.05;
-  letter-spacing: -0.02em;
+  font-weight: 600;
+  font-style: normal;
+  font-size: clamp(22px, 2.4vw, 32px);
+  line-height: 1.15;
+  letter-spacing: -0.015em;
   color: var(--paper);
   margin: 1.6em 0 0.5em;
 }
@@ -1294,11 +1260,11 @@ a.md-header__button.md-logo:hover ~ .md-header__title .md-header__topic,
 
 .md-typeset p, .md-typeset li { color: var(--paper); }
 .md-typeset strong { color: var(--paper); font-weight: 700; }
-.md-typeset em { font-family: var(--serif); font-style: italic; }
+.md-typeset em { font-family: var(--sans); font-style: italic; }
 
 .md-typeset a {
   color: var(--signal);
-  border-bottom: 1px solid rgba(255,90,31,0.25);
+  border-bottom: 1px solid rgba(79,199,230,0.25);
   text-decoration: none;
   transition: color .15s, border-color .15s;
 }
@@ -1362,7 +1328,7 @@ a.md-header__button.md-logo:hover ~ .md-header__title .md-header__topic,
 }
 .md-clipboard {
   color: var(--mute);
-  background: rgba(11,11,9,0.6);
+  background: rgba(13,15,18,0.6);
   border-radius: 2px;
 }
 .md-clipboard:hover { color: var(--signal); }
@@ -1385,14 +1351,15 @@ a.md-header__button.md-logo:hover ~ .md-header__title .md-header__topic,
 /* Admonitions */
 .md-typeset .admonition,
 .md-typeset details {
+  --adm: var(--signal);
   background: var(--ink-2);
   border: 1px solid var(--rule);
-  border-left: 2px solid var(--signal);
   border-radius: 2px;
   box-shadow: none;
   font-size: 14.5px;
   color: var(--paper-dim);
 }
+/* Type is signalled by the title + icon color, not an accent left rail. */
 .md-typeset .admonition-title,
 .md-typeset summary {
   background: transparent;
@@ -1401,22 +1368,32 @@ a.md-header__button.md-logo:hover ~ .md-header__title .md-header__topic,
   font-weight: 700;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: var(--paper);
+  color: var(--adm);
   border-bottom: 1px solid var(--rule);
 }
 .md-typeset .admonition-title::before,
-.md-typeset summary::before { background-color: var(--signal); }
+.md-typeset summary::before { background-color: var(--adm); }
 
 .md-typeset .admonition.note,
-.md-typeset details.note { border-left-color: var(--cool); }
+.md-typeset details.note { --adm: var(--cool); }
 .md-typeset .admonition.warning,
-.md-typeset details.warning { border-left-color: var(--signal); }
+.md-typeset details.warning { --adm: var(--signal); }
 .md-typeset .admonition.danger,
-.md-typeset details.danger { border-left-color: var(--signal); }
+.md-typeset details.danger { --adm: var(--signal); }
 .md-typeset .admonition.tip,
-.md-typeset details.tip { border-left-color: var(--acid); }
+.md-typeset details.tip { --adm: var(--acid); }
 .md-typeset .admonition.success,
-.md-typeset details.success { border-left-color: var(--acid); }
+.md-typeset details.success { --adm: var(--acid); }
+
+/* Material ships per-type border + icon colors as 3-class selectors
+   (e.g. `.md-typeset .admonition.warning { border-color: #ff9100 }`) that
+   outrank the neutral base rule above and reintroduce amber/blue boxes.
+   Match that specificity with `[class]` so every admonition keeps a neutral
+   border and takes its title + icon color only from --adm — no colored box. */
+.md-typeset .admonition[class],
+.md-typeset details[class] { border-color: var(--rule); }
+.md-typeset .admonition[class] > .admonition-title::before,
+.md-typeset details[class] > summary::before { background-color: var(--adm); }
 
 /* Tables */
 .md-typeset table:not([class]) {
@@ -1513,10 +1490,20 @@ a.md-header__button.md-logo:hover ~ .md-header__title .md-header__topic,
 .md-copyright a:hover { color: var(--signal); }
 .md-social a { color: var(--mute); }
 .md-social a:hover { color: var(--signal); }
-.md-footer__title { background: var(--ink); color: var(--paper); }
-.md-footer__direction { color: var(--mute); font-family: var(--mono); }
-.md-footer__link { color: var(--paper-dim); }
-.md-footer__link:hover { color: var(--signal); opacity: 1; }
+.md-footer__inner { padding: 8px 0; gap: 12px; }
+.md-footer__link { color: var(--paper-dim); padding: 20px 16px; border-radius: 6px; transition: background .2s, color .2s; opacity: 1; }
+.md-footer__link:hover { color: var(--signal); background: var(--ink-3); }
+.md-footer__title { background: transparent; color: var(--paper); font-weight: 500; line-height: 1.3; }
+.md-footer__direction {
+  color: var(--mute);
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  opacity: 1;
+}
+.md-footer__button { color: var(--mute); transition: color .2s; }
+.md-footer__link:hover .md-footer__button { color: var(--signal); }
 
 /* Hide Material's default content button on homepage */
 .page--home .md-content__button { display: none; }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,7 +6,7 @@ repo_url: https://github.com/txn2/kubefwd
 repo_name: txn2/kubefwd
 edit_uri: edit/master/docs/
 
-copyright: Copyright &copy; 2018 - 2025 Craig Johnston / Deasil Works, Inc.
+copyright: Copyright &copy; 2018 - 2025 <a href="https://imti.co">Craig Johnston</a> / <a href="https://deasil.works">Deasil Works, Inc.</a> / <a href="https://plexara.io">Plexara</a>
 
 theme:
   name: material


### PR DESCRIPTION
Ports the txn2 docs design-system re-skin from mcp-data-platform so the sister documentation sites stay visually parity-mapped.

Type and color: replaces the Fraunces display serif with Geist / Geist Mono (non-italic mono headings, Geist body) and moves the palette to a graphite-grey ground (`--ink #1E232A`) with a single restrained cyan accent, remapping the former orange tints to cyan.

Chrome: removes the live UTC clock from the homepage rail and footer, de-rails admonitions (Material's per-type border colors neutralized so type reads from the title/icon color), cleans up the prev/next footer, and links the copyright to imti.co / deasil.works / plexara.io.

Homepage: removes the split-word dropcap, the 001-00N numbering and caps chips from the feature list, and the hero version/go badge. The mono hero display is capped so all three rows clear the right-pinned stamp.

Verification: `mkdocs build --strict` passes with no warnings (the gate CI runs in `.github/workflows/docs.yml`); the homepage was checked in a browser.
