### PR TITLE
ci/deps: roll up open Dependabot bumps

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,7 @@ jobs:
           cache: true
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/init@e0647621c2984b5ed2f768cb892365bf2a616ad1 # v4.37.2
         with:
           languages: go
 
@@ -38,6 +38,6 @@ jobs:
         run: go build ./...
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/analyze@e0647621c2984b5ed2f768cb892365bf2a616ad1 # v4.37.2
         with:
           category: "/language:go"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.x'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,7 @@ jobs:
         # This action is actively maintained and Node 24-based. Attestations are
         # stored in GitHub's attestation API; verify with:
         #   gh attestation verify <artifact> --repo txn2/kubefwd
-        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
+        uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4.2.0
         with:
           subject-checksums: /tmp/checksums.txt
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -73,6 +73,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v3
+        uses: github/codeql-action/upload-sarif@e0647621c2984b5ed2f768cb892365bf2a616ad1 # v3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Rolls up the open Dependabot GitHub Actions PRs into one change so the overlapping workflow edits (`codeql.yml` is touched by both `init` and `analyze`) do not rebase against each other.

## Actions

| Action | From | To |
|--------|------|----|
| `actions/setup-python` | v6.3.0 | v7.0.0 |
| `github/codeql-action/init` | v4.37.0 | v4.37.2 |
| `github/codeql-action/analyze` | v4.37.0 | v4.37.2 |
| `github/codeql-action/upload-sarif` | v4.37.0 | v4.37.2 |
| `actions/attest` | v4.1.1 | v4.2.0 |

Every action SHA was resolved against upstream and matches the commit its tag points at (codeql-action's annotated tag was dereferenced). Refs stay pinned to full 40-char SHAs, so `validate-action-shas.sh` passes.

Supersedes #554, #555, #556, #557, #558.